### PR TITLE
Sync language with EN

### DIFF
--- a/language/constants.xml
+++ b/language/constants.xml
@@ -1,0 +1,385 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: f4f96ef8b2a95283c92ea2183fe1dedf06f3ad22 Maintainer: grzesiek Status: ready -->
+<!-- $Revision$ -->
+ <chapter xml:id="language.constants" xmlns="http://docbook.org/ns/docbook">
+  <title>Constants</title>
+
+  <simpara>
+   Stała jest identyfikatorem (nazwą) prostej wartości. Jak sama
+   nazwa wskazuje, wartość ta nie może się zmienić podczas wykonywania
+   skryptu (z wyjątkiem <link linkend="language.constants.magic">
+   stałych magicznych</link>, które w rzeczywistości nie są stałymi).
+   Wielkość liter w stałych ma znaczenie. Zgodnie z konwencją, identyfikatory
+   stałych są zawsze pisane wielkimi literami.
+  </simpara>
+
+  <note>
+   <para>
+    Przed PHP 8.0.0, stałe zdefiniowane przy użyciu funkcji <function>define</function>
+    mogły nie uwzględniać wielkości liter.
+   </para>
+  </note>
+
+  <para>
+   Nazwa stałej podlega tym samym zasadom, co każda etykieta w PHP. 
+   Prawidłowa nazwa stałej zaczyna się od litery lub podkreślenia,
+   po których następuje dowolna liczba liter, cyfr lub podkreśleń.
+   Jako wyrażenie regularne, może być wyrażona w następujący sposób:
+   <code>^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$</code>
+  </para>
+  <para>
+   Możliwe jest zdefiniowanie za pomocą <function>define</function> satłych z
+   zastrzeżonymi lub nawet nieważnymi nazwami, których wartość można pobrać tylko za
+   pomocą funkcji <function>constant</function>. Nie jest to jednak zalecane.
+  </para>
+  &tip.userlandnaming;
+  <para>
+<!-- TODO Move into syntax section? -->
+   <example>
+    <title>Prawidłowe i nieprawidłowe nazwy stałych</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+// Prawidłowe nazwy stałych
+define("FOO",     "something");
+define("FOO2",    "something else");
+define("FOO_BAR", "something more");
+
+// Nieprawidłowe nazwy stałych
+define("2FOO",    "something");
+
+// Jest to poprawne, ale należy tego unikać:
+// PHP może pewnego dnia dostarczyć magiczną stałą
+// która zepsuje skrypt
+define("__FOO__", "something"); 
+
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+  <note>
+   <simpara>
+    Dla naszych celów litera to a-z, A-Z i znaki ASCII
+    od 128 do 255 (0x80-0xff).
+   </simpara>
+  </note>
+
+  <simpara>
+   Podobnie jak &link.superglobals;, zakres stałej jest globalny.
+   Dostęp do stałych można uzyskać z dowolnego miejsca w skrypcie bez względu na zakres.
+   Aby uzyskać więcej informacji na temat zakresu, przeczytaj sekcję podręcznika dotyczącą
+   <link linkend="language.variables.scope">zakresu zmiennej</link>.
+  </simpara>
+
+  <note>
+   <simpara>
+    Począwszy od PHP 7.1.0, stałe klasowe mogą deklarować widoczność protected
+    lub private, czyniąc je dostępnymi tylko w hierarchicznym zakresie klasy,
+    w której są zdefiniowane.
+   </simpara>
+  </note>
+
+  <sect1 xml:id="language.constants.syntax">
+   <title>Składnia</title>
+   <simpara>
+    Stałe mogą być definiowane za pomocą słowa kluczowego <literal>const</literal>,
+    lub za pomocą funkcji <function>define</function>.
+    Podczas gdy <function>define</function> pozwala na zdefiniowanie stałej
+    dla dowolnego wyrażenia, słowo kluczowe <literal>const</literal> ma
+    ograniczenia opisane w następnym akapicie.
+    Gdy stała zostanie zdefiniowana, nigdy nie może zostać
+    zmieniona lub niezdefiniowana.
+   </simpara>
+   <simpara>
+    Podczas używania słowa kluczowego <literal>const</literal>,
+    akceptowane są tylko wyrażenia skalarne (<type>bool</type>, <type>int</type>,
+    <type>float</type> i <type>string</type>) oraz stałe
+    <type>array</type>s zawierające tylko wyrażenia skalarne.
+    Możliwe jest zdefiniowanie stałych jako <type>resource</type>,
+    ale należy tego unikać, ponieważ może to spowodować nieoczekiwane wyniki.
+   </simpara>
+   <simpara>
+    Dostęp do wartości stałej uzyskuje się po prostu poprzez podanie jej nazwy.
+    W przeciwieństwie do zmiennych, stała <emphasis>nie</emphasis> jest poprzedzona
+    <literal>$</literal>.
+    Możliwe jest również użycie funkcji <function>constant</function> do
+    odczytania wartości stałej, jeśli nazwa stałej jest uzyskiwana dynamicznie. 
+    Użyj funkcji <function>get_defined_constants</function>, aby uzyskać listę
+    wszystkich zdefiniowanych stałych.
+   </simpara>
+
+   <note>
+    <simpara>
+     Stałe i zmienne (globalne) znajdują się w innej przestrzeni nazw. 
+     Oznacza to, że na przykład &true; i 
+     <varname>$TRUE</varname> są generalnie różne.
+    </simpara>
+   </note>
+
+   <simpara>
+    Jeśli zostanie użyta niezdefiniowana stała, zostanie zgłoszony błąd <classname>Error</classname>.
+    Przed PHP 8.0.0, niezdefiniowane stałe były interpretowane jako gołe słowo
+    <type>string</type>, t.j. (CONSTANT vs "CONSTANT"). 
+    To rozwiązanie awaryjne jest przestarzałe od PHP 7.2.0, a błąd poziomu
+    <constant>E_WARNING</constant> jest zgłaszany, gdy tak się stanie.
+    Przed PHP 7.2.0, zamiast tego zgłaszany był błąd poziomu
+    <link linkend="ref.errorfunc">E_NOTICE</link>.
+    Zobacz także wpis w podręczniku, dlaczego 
+    <link linkend="language.types.array.foo-bar">$foo[bar]</link> jest
+    błędne (chyba, że <literal>bar</literal> jest stałą).
+    Nie dotyczy to <link
+    linkend="language.namespaces.rules">(w pełni) kwalifikowanych stałych</link>,
+    które zawsze zgłoszą błąd <classname>Error</classname>, jeśli są niezdefiniowane.
+   </simpara>
+
+   <note>
+    <simpara>
+     Aby sprawdzić, czy stała jest ustawiona, należy użyć funkcji <function>defined</function>.
+    </simpara>
+   </note>
+
+   <para>
+    To są różnice między stałymi i zmiennymi:
+    <itemizedlist>
+     <listitem>
+      <simpara>
+       Stałe nie mają przed sobą znaku dolara
+       (<literal>$</literal>);
+      </simpara>
+     </listitem>
+     <listitem>
+      <simpara>
+       Stałe mogą być definiowane i dostępne w dowolnym miejscu bez względu na
+       zasady dotyczące zakresu zmiennych;
+      </simpara>
+     </listitem>
+     <listitem>
+      <simpara>
+       Stałe nie mogą być przedefiniowane lub niezdefiniowane po ich ustawieniu;
+       oraz
+      </simpara>
+     </listitem>
+     <listitem>
+      <simpara>
+       Stałe mogą być oceniane tylko jako wartości skalarne lub tablice.
+      </simpara>
+     </listitem>
+    </itemizedlist>
+   </para>
+
+   <para>
+    <example>
+     <title>Defining Constants</title>
+     <programlisting role="php">
+<![CDATA[
+<?php
+define("CONSTANT", "Hello world.");
+echo CONSTANT; // zwróci "Hello world."
+echo Constant; // Zgłosi błąd: Niezdefiniowana stała „Constant”
+               // Przed PHP 8.0.0, zwróci „Constant” i wyświetla ostrzeżenie.
+?>
+]]>
+     </programlisting>
+    </example>
+   </para>
+
+   <para>
+    <example>
+     <title>Definiowanie Stałych przy użyciu słowa kluczowego <literal>const</literal></title>
+     <programlisting role="php">
+<![CDATA[
+<?php
+// Prosta wartość skalarna
+const CONSTANT = 'Hello World';
+
+echo CONSTANT;
+
+// Wyrażenie skalarne
+const ANOTHER_CONST = CONSTANT.'; Goodbye World';
+echo ANOTHER_CONST;
+
+const ANIMALS = array('dog', 'cat', 'bird');
+echo ANIMALS[1]; // zwróci "cat"
+
+// Tablice stałej
+define('ANIMALS', array(
+    'dog',
+    'cat',
+    'bird'
+));
+echo ANIMALS[1]; // zwróci "cat"
+?>
+]]>
+     </programlisting>
+    </example>
+   </para>
+
+   <note>
+    <para>
+     W przeciwieństwie do definiowania stałych za pomocą <function>define</function>,
+     stałe zdefiniowane za pomocą słowa kluczowego <literal>const</literal> muszą być
+     zadeklarowane w zakresie najwyższego poziomu, ponieważ są definiowane w czasie kompilacji.
+     Oznacza to, że nie można ich zadeklarować wewnątrz funkcji, pętli, instrukcji
+     <literal>if</literal> lub bloków
+     <literal>try</literal>/<literal>catch</literal>.
+    </para>
+   </note>
+
+   <sect2 role="seealso">
+    &reftitle.seealso;
+    <para>
+     <simplelist>
+      <member><link linkend="language.oop5.constants">Stałe Klasy</link></member>
+     </simplelist>
+    </para>
+   </sect2>
+  </sect1>
+  
+  <sect1 xml:id="language.constants.predefined">
+   <title>Predefiniowane stałe</title>
+
+   <simpara>
+    PHP udostępnia dużą liczbę <link
+    linkend="reserved.constants">predefiniowanych stałych</link> dla każdego
+    uruchamianego skryptu. Wiele z tych stałych jest jednak tworzonych przez
+    różne rozszerzenia i będą one obecne tylko wtedy, gdy te rozszerzenia
+    są dostępne, albo poprzez dynamiczne ładowanie, albo dlatego, że zostały
+    skompilowane.
+   </simpara>
+  </sect1>
+
+  <sect1 xml:id="language.constants.magic">
+   <title>Stałe magiczne</title>
+   <para>
+    Istnieje kilka magicznych stałych, które zmieniają się w zależności
+    od tego, gdzie są używane. Na przykład wartość stałej
+    <constant>__LINE__</constant> zależy od linii, w której jest
+    używana w skrypcie. Wszystkie te „magiczne” stałe są rozwiązywane w
+    czasie kompilacji, w przeciwieństwie do zwykłych stałych, które są rozwiązywane w czasie wykonywania.
+    Te specjalne stałe nie uwzględniają wielkości liter i są następujące:
+   </para>
+   <para>
+    <table>
+     <title>Stałe magiczne PHP</title>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Name;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row xml:id="constant.line">
+        <entry><constant>__LINE__</constant></entry>
+        <entry>
+         Bieżący numer linii pliku.
+        </entry>
+       </row>
+       <row xml:id="constant.file">
+        <entry><constant>__FILE__</constant></entry>
+        <entry>
+         Pełna ścieżka i nazwa pliku z rozwiązanymi dowiązaniami symbolicznymi.
+         W przypadku użycia wewnątrz include, zwracana jest nazwa dołączonego pliku.
+        </entry>
+       </row>
+       <row xml:id="constant.dir">
+        <entry><constant>__DIR__</constant></entry>
+        <entry>
+         Katalog pliku. Jeśli użyta jest wewnątrz include,
+         zwracany jest katalog dołączonego pliku. Jest to równoważne
+         dla <literal>dirname(__FILE__)</literal>. Nazwa katalogu
+         nie zawiera końcowego ukośnika, chyba że jest to katalog główny.
+        </entry>
+       </row>
+       <row xml:id="constant.function">
+        <entry><constant>__FUNCTION__</constant></entry>
+        <entry>
+         Nazwa funkcji lub <literal>{domknięcie}</literal> dla funkcji anonimowych.
+        </entry>
+       </row>
+       <row xml:id="constant.class">
+        <entry><constant>__CLASS__</constant></entry>
+        <entry>
+         Nazwa klasy. Nazwa klasy zawiera przestrzeń nazw, w której
+         została zadeklarowana (n.p. <literal>Foo\Bar</literal>).
+         W przypadku użycia wewnątrz metody traita,
+         <constant>__CLASS__</constant> jest nazwą klasy, w której trait jest
+         używany.
+        </entry>
+       </row>
+       <row xml:id="constant.trait">
+        <entry><constant>__TRAIT__</constant></entry>
+        <entry>
+         Nazwa traita. Nazwa traita zawiera przestrzeń nazw, w 
+         której został zadeklarowany (e.g. <literal>Foo\Bar</literal>).
+        </entry>
+       </row>
+       <row xml:id="constant.method">
+        <entry><constant>__METHOD__</constant></entry>
+        <entry>
+         Nazwa metody klasy.
+        </entry>
+       </row>
+       <row xml:id="constant.property">
+        <entry><constant>__PROPERTY__</constant></entry>
+        <entry>
+         Ważne tylko wewnątrz
+         <link linkend="language.oop5.property-hooks">haku właściwości</link>.
+         Jest ona równa nazwie właściwości.
+        </entry>
+       </row>
+       <row xml:id="constant.namespace">
+        <entry><constant>__NAMESPACE__</constant></entry>
+        <entry>
+         Nazwa bieżącej przestrzeni nazw.
+        </entry>
+       </row>
+       <row xml:id="constant.coloncolonclass">
+        <entry><constant><replaceable>ClassName</replaceable>::class</constant></entry>
+        <entry>
+         W pełni kwalifikowana nazwa klasy.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </table>
+   </para>
+
+   <sect2 role="seealso">
+    &reftitle.seealso;
+    <para>
+     <simplelist>
+      <member><link linkend="language.oop5.basic.class.class">::class</link></member>
+      <member><function>get_class</function></member>
+      <member><function>get_object_vars</function></member>
+      <member><function>file_exists</function></member>
+      <member><function>function_exists</function></member>
+     </simplelist>
+    </para>
+   </sect2>
+
+  </sect1>
+ </chapter>
+ 
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -1,0 +1,990 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 3bc8fc7b9785c335e55d83986e6cd8968498dcfb Maintainer: grzesiek Status: ready -->
+<!-- $Revision$ -->
+ <chapter xml:id="language.enumerations" xmlns="http://docbook.org/ns/docbook">
+  <title>Wyliczenia</title>
+  <sect1 xml:id="language.enumerations.overview">
+   <title>Przegląd wyliczeń</title>
+   <?phpdoc print-version-for="enumerations"?>
+
+   <para>
+    Wyliczenia lub "Enumy" pozwalają programiście zdefiniować niestandardowy typ, który jest ograniczony
+    do jednej z dyskretnej liczby możliwych wartości. Może to być szczególnie pomocne przy definiowaniu
+    modelu domeny, ponieważ umożliwia "uniemożliwienie reprezentowania nieważnych stanów."
+   </para>
+
+   <para>
+    Enumy pojawiają się w wielu językach z różnymi funkcjami. W PHP, Enumy są specjalnym
+    rodzajem obiektów. Enum samo w sobie jest klasą, a jego możliwe zbiory wartości są
+    pojedynczymi obiektami tej klasy. Oznacza to, że zbiory wartości Enuma są poprawnymi obiektami
+    i mogą być używane wszędzie tam, gdzie obiekt może być użyty, włączając w to sprawdzanie typów.
+   </para>
+
+   <para>
+    Najpopularniejszym przykładem wyliczeń jest wbudowany typ boolean, który jest
+    typem wyliczeniowym z legalnymi wartościami &true; i &false;.
+    Enumy pozwalają programistom definiować własne, dowolnie rozbudowane wyliczenia.
+   </para>
+  </sect1>
+  <sect1 xml:id="language.enumerations.basics">
+   <title>Podstawowe wyliczenia</title>
+
+   <para>
+    Enumy są podobne do klas i dzielą te same przestrzenie nazw co klasy, interfejsy i traity.
+    Są one również automatycznie ładowane w ten sam sposób. Enumy definiują nowy typ, który ma stałą,
+    ograniczoną liczbę możliwych legalnych wartości.
+   </para>
+
+
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+enum Suit
+{
+    case Hearts;
+    case Diamonds;
+    case Clubs;
+    case Spades;
+}
+?>
+]]>
+   </programlisting>
+
+   <para>
+    Ta deklaracja tworzy nowy typ wyliczeniowy o nazwie <literal>Suit</literal>, który ma
+    cztery i tylko cztery legalne wartości: <literal>Suit::Hearts</literal>, <literal>Suit::Diamonds</literal>,
+    <literal>Suit::Clubs</literal> i <literal>Suit::Spades</literal>. Zmienne mogą być przypisane
+    do jednej z tych legalnych wartości. Funkcja może być sprawdzana pod kątem typu wyliczeniowego,
+    w którym to przypadku mogą być przekazywane tylko wartości tego typu.
+   </para>
+
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+function pick_a_card(Suit $suit)
+{
+    /* ... */
+}
+
+$val = Suit::Diamonds;
+
+// OK
+pick_a_card($val);
+
+// OK
+pick_a_card(Suit::Clubs);
+
+// TypeError: pick_a_card(): Argument #1 ($suit) must be of type Suit, string given
+pick_a_card('Spades');
+?>
+]]>
+   </programlisting>
+
+   <para>
+    Wyliczenie może mieć zero lub więcej definicji <literal>case</literal>, bez maksimum.
+    Enumy o zerowej ilości case są poprawne składniowo, choć raczej bezużyteczne.
+   </para>
+
+   <para>
+    Dla przypadków wyliczeń obowiązują te same zasady składni, co dla każdej etykiety w PHP, zobacz
+    <link linkend="language.constants">Stałe</link>.
+   </para>
+
+   <para>
+    Domyślnie instrukcje case nie są wewnętrznie wspierane przez wartość skalarną.
+    Oznacza to, że <literal>Suit::Hearts</literal> nie jest równy <literal>"0"</literal>.
+    Zamiast tego, każdy case jest wspierany przez pojedynczy obiekt o tej nazwie. Oznacza to, że:
+   </para>
+
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$a = Suit::Spades;
+$b = Suit::Spades;
+
+$a === $b; // true
+
+$a instanceof Suit;  // true
+?>
+]]>
+   </programlisting>
+
+   <para>
+    Oznacza to również, że wartości enumów nigdy nie są <literal>&lt;</literal> lub <literal>&gt;</literal> względem siebie,
+    ponieważ te porównania nie mają znaczenia na obiektach. Te porównania zawsze
+    zwrócą &false; podczas pracy z wartościami enuma.
+   </para>
+
+   <para>
+    Ten typ instrukcji case, bez powiązanych danych, nazywany jest "Pure Case".  Enumy zawierające
+    tylko Pure Case nazywane są Pure Enum.
+   </para>
+
+   <para>
+    Wszystkie Pure Case są zaimplementowane jako instancje ich typu enuma. Typ enuma jest reprezentowany wewnętrznie jako klasa.
+   </para>
+
+   <para>
+    Wszystkie instrukcje case mają właściwość tylko do odczytu <literal>nazwę</literal>, która jest rozróżniającą
+    wielkość liter nazwą samej instrukcji case.
+   </para>
+
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+print Suit::Spades->name;
+// prints "Spades"
+?>
+]]>
+   </programlisting>
+
+   <para>
+    Możliwe jest również użycie funkcji  <function>defined</function> i <function>constant</function>
+    do sprawdzenia istnienia lub odczytania case enuma, jeśli nazwa jest uzyskiwana dynamicznie.
+    Jest to jednak odradzane, ponieważ użycie <link linkend="language.enumerations.backed">Enuma backed</link>
+    powinno działać w większości przypadków użycia.
+   </para>
+
+  </sect1>
+
+ <sect1 xml:id="language.enumerations.backed">
+  <title>Wyliczenia backed</title>
+
+  <para>
+   Domyślnie Wyliczone Case nie mają skalarnego odpowiednika. Są to po prostu obiekty singleton. Istnieje
+   jednak wiele przypadków, w których Wyliczony Case musi być w stanie zaokrąglić do bazy danych lub
+   podobnego magazynu danych, więc posiadanie wbudowanej wartoścci skalarnej (a zatem trywialnie serializowalnego)
+   odpowiednika zdefiniowanego wewnętrznie jest przydatne.
+  </para>
+
+  <para>Aby zdefiniować skalarny odpowiednik dla Wyliczeń, składnia jest następująca:</para>
+
+  <programlisting role="php">
+<![CDATA[
+<?php
+
+enum Suit: string
+{
+    case Hearts = 'H';
+    case Diamonds = 'D';
+    case Clubs = 'C';
+    case Spades = 'S';
+}
+?>
+]]>
+  </programlisting>
+
+  <para>
+   Case, który ma odpowiednik skalarny, nazywany jest Backed Case, ponieważ jest "Utworzony"
+   przez prostszą wartość. Enum, który zawiera wszystkie Backed Case nazywany jest "Backed Enum".
+   Backed Enum może zawierać tylko Backed Cases. Pure Enum może zawierać tylko Pure Case.
+  </para>
+
+  <para>
+   Backed Enum może być utworzony przez typy <literal>int</literal> lub <literal>string</literal>,
+   a dane wyliczenie obsługuje tylko jeden typ w danym czasie (tj. nie ma uni <literal>int|string</literal>).
+   Jeśli wyliczenie jest oznaczone jako posiadające skalarny odpowiednik, to wszystkie przypadki muszą mieć
+   unikalny skalarny odpowiednik zdefiniowany jawnie. Nie ma automatycznie generowanych odpowiedników
+   skalarnych (np. sekwencyjnych liczb całkowitych). Backed case muszą być unikalne; dwa backed enum case nie mogą
+   mieć tego samego skalarnego odpowiednika. Stała może jednak odnosić się do przypadku, skutecznie
+   tworząc alias. Zobacz <link linkend="language.enumerations.constants">Stałe wyliczenia</link>.
+  </para>
+
+  <para>
+   Równoważne wartości mogą być stałym wyrażeniem skalarnym.
+   Przed PHP 8.2.0 równoważne wartości musiały być literałami lub wyrażeniami literałowymi.
+   Oznacza to, że stałe i wyrażenia stałe nie były obsługiwane.
+   Oznacza to, że <code>1 + 1</code> było dozwolone, ale nie <code>1 + SOME_CONST</code>.
+  </para>
+
+  <para>
+   Backed Case mają dodatkową właściwość tylko do odczytu <literal>value</literal>, która jest wartością
+   określoną w definicji.
+  </para>
+
+  <programlisting role="php">
+<![CDATA[
+<?php
+
+print Suit::Clubs->value;
+// Prints "C"
+?>
+]]>
+  </programlisting>
+
+  <para>
+   Aby wymusić właściwość <literal>value</literal> jako tylko do odczytu, nie można przypisać zmiennej
+   jako odniesienia do niej. Oznacza to, że poniższy kod powoduje błąd:
+  </para>
+
+  <programlisting role="php">
+<![CDATA[
+<?php
+
+$suit = Suit::Clubs;
+$ref = &$suit->value;
+// Błąd: Nie można uzyskać odniesienia do właściwości Suit::$value
+?>
+]]>
+  </programlisting>
+
+  <para>
+   Enumy backed implementują wewnętrzny interfejs <interfacename>BackedEnum</interfacename>,
+   który udostępnia dwie dodatkowe metody::
+  </para>
+
+  <simplelist>
+   <member>
+    <literal>from(int|string): self</literal> przyjmie skalar i zwróci odpowiadający mu
+    Case Enuma. Jeśli nie zostanie znaleziony, zostanie zgłoszony błąd <classname>ValueError</classname>.
+    Jest to przydatne głównie w przypadkach, gdy skalar wejściowy jest zaufany, a brakująca wartość enuma powinna
+    być uznana za błąd zatrzymujący aplikację.
+   </member>
+   <member>
+    <literal>tryFrom(int|string): ?self</literal> przyjmie skalar i zwróci
+    odpowiadający mu Case Enuma. Jeśli nie zostanie znaleziony, zwróci <literal>null</literal>.
+    Jest to przydatne głównie w przypadkach, gdy skalar wejściowy jest niegodny zaufania, a wywołujący chce
+    zaimplementować własną obsługę błędów lub logikę wartości domyślnych.
+   </member>
+  </simplelist>
+
+  <para>
+   Metody <literal>from()</literal> i <literal>tryFrom()</literal> stosują się do standardowych
+   reguł słabego/silnego typowania. W trybie słabego typowania, przekazanie liczby całkowitej lub ciągu jest dopuszczalne,
+   a system odpowiednio wymusi wartość. Przekazanie liczby zmiennoprzecinkowej również zadziała i
+   zostanie wymuszone. W trybie ścisłego typowania, przekazanie liczby całkowitej do <literal>from()</literal> w
+   wyliczeniu opartym na ciągu (lub odwrotnie) spowoduje błąd <classname>TypeError</classname>,
+   podobnie jak float we wszystkich okolicznościach. Wszystkie inne typy parametrów wyrzucą błąd TypeError
+   w obu trybach.
+  </para>
+
+  <programlisting role="php">
+<![CDATA[
+<?php
+
+$record = get_stuff_from_database($id);
+print $record['suit'];
+
+$suit =  Suit::from($record['suit']);
+// Invalid data throws a ValueError: "X" is not a valid scalar value for enum "Suit"
+print $suit->value;
+
+$suit = Suit::tryFrom('A') ?? Suit::Spades;
+// Invalid data returns null, so Suit::Spades is used instead.
+print $suit->value;
+?>
+]]>
+  </programlisting>
+
+  <para>Ręczne zdefiniowanie metody <literal>from()</literal> lub <literal>tryFrom()</literal> w Backed Enum spowoduje błąd krytyczny.</para>
+
+  </sect1>
+
+ <sect1 xml:id="language.enumerations.methods">
+  <title>Metody wyliczeń</title>
+
+  <para>
+   Enumy (zarówno Enumy Pure, jak i Enumy Backed) mogą zawierać metody i mogą implementować interfejsy.
+   Jeśli Enum implementuje interfejs, wówczas każde sprawdzenie typu dla tego interfejsu zaakceptuje również
+   wszystkie przypadki tego Enuma.
+  </para>
+
+  <programlisting role="php">
+<![CDATA[
+<?php
+
+interface Colorful
+{
+    public function color(): string;
+}
+
+enum Suit implements Colorful
+{
+    case Hearts;
+    case Diamonds;
+    case Clubs;
+    case Spades;
+
+    // Spełnia kontrakt interfejsu.
+    public function color(): string
+    {
+        return match($this) {
+            Suit::Hearts, Suit::Diamonds => 'Red',
+            Suit::Clubs, Suit::Spades => 'Black',
+        };
+    }
+
+    // Nie jest częścią interfejsu; nie ma problemu.
+    public function shape(): string
+    {
+        return "Rectangle";
+    }
+}
+
+function paint(Colorful $c)
+{
+   /* ... */
+}
+
+paint(Suit::Clubs);  // Działa
+
+print Suit::Diamonds->shape(); // Wyświetli "Rectangle"
+?>
+]]>
+  </programlisting>
+
+  <para>
+   W tym przykładzie wszystkie cztery wystąpienia <literal>Suit</literal> mają dwie metody
+   <literal>color()</literal> i <literal>shape()</literal>. Jeśli chodzi o wywoływanie kodu
+   i sprawdzanie typów, zachowują się one dokładnie tak samo, jak każde inna instancja obiektu.
+  </para>
+
+  <para>
+   W przypadku Backed Enum deklaracja interfejsu następuje po deklaracji typu backed.
+  </para>
+
+  <programlisting role="php">
+   <![CDATA[
+<?php
+
+interface Colorful
+{
+    public function color(): string;
+}
+
+enum Suit: string implements Colorful
+{
+    case Hearts = 'H';
+    case Diamonds = 'D';
+    case Clubs = 'C';
+    case Spades = 'S';
+
+    // Spełnienie kontraktu interfejsu.
+    public function color(): string
+    {
+        return match($this) {
+            Suit::Hearts, Suit::Diamonds => 'Red',
+            Suit::Clubs, Suit::Spades => 'Black',
+        };
+    }
+}
+?>
+]]>
+  </programlisting>
+
+  <para>
+   Wewnątrz metody zdefiniowana jest zmienna <literal>$this</literal> która odwołuje się do instancji Case.
+  </para>
+
+  <para>
+   Metody mogą być dowolnie złożone, ale w praktyce zazwyczaj zwracają wartość statyczną lub
+   &match; dla <literal>$this</literal> aby zapewnić
+   różne wyniki w różnych przypadkach.
+  </para>
+
+  <para>
+   Należy zauważyć, że w tym przypadku lepszą praktyką modelowania danych byłoby również zdefiniowanie
+   Typu Enum <literal>SuitColor</literal> z wartościami Red i Black i zwrócenie go zamiast tego.
+   Jednak skomplikowałoby to ten przykład.
+  </para>
+
+  <para>
+   Powyższa hierarchia jest logicznie podobna do następującej struktury klas
+   (choć nie jest to faktyczny kod, który jest uruchamiany):
+  </para>
+
+  <programlisting role="php">
+<![CDATA[
+<?php
+
+interface Colorful
+{
+    public function color(): string;
+}
+
+final class Suit implements UnitEnum, Colorful
+{
+    public const Hearts = new self('Hearts');
+    public const Diamonds = new self('Diamonds');
+    public const Clubs = new self('Clubs');
+    public const Spades = new self('Spades');
+
+    private function __construct(public readonly string $name) {}
+
+    public function color(): string
+    {
+        return match($this) {
+            Suit::Hearts, Suit::Diamonds => 'Red',
+            Suit::Clubs, Suit::Spades => 'Black',
+        };
+    }
+
+    public function shape(): string
+    {
+        return "Rectangle";
+    }
+
+    public static function cases(): array
+    {
+        // Nielegalna metoda, ponieważ ręczne definiowanie metody cases() na Enumie jest niedozwolone.
+        // Zobacz także sekcję "Listowanie wartości".
+    }
+}
+?>
+]]>
+  </programlisting>
+
+  <para>
+   Metody mogą być publiczne, prywatne lub chronione, chociaż w praktyce prywatne i
+   chronione są równoważne, ponieważ dziedziczenie nie jest dozwolone.
+  </para>
+
+ </sect1>
+
+ <sect1 xml:id="language.enumerations.static-methods">
+  <title>Statyczne metody wyliczeń</title>
+
+  <para>
+   Wyliczenia mogą również posiadać metody statyczne. Użycie metod statycznych na
+   samym wyliczeniu jest przede wszystkim dla alternatywnych konstruktorów. Np:
+  </para>
+
+  <programlisting role="php">
+<![CDATA[
+<?php
+
+enum Size
+{
+    case Small;
+    case Medium;
+    case Large;
+
+    public static function fromLength(int $cm): self
+    {
+        return match(true) {
+            $cm < 50 => self::Small,
+            $cm < 100 => self::Medium,
+            default => self::Large,
+        };
+    }
+}
+?>
+]]>
+  </programlisting>
+
+  <para>
+   Metody statyczne mogą być publiczne, prywatne lub chronione, chociaż w praktyce prywatne
+   i chronione są równoważne, ponieważ dziedziczenie nie jest dozwolone.
+  </para>
+
+ </sect1>
+
+ <sect1 xml:id="language.enumerations.constants">
+  <title>Stałe wyliczeń</title>
+
+  <para>
+   Wyliczenia mogą zawierać stałe, które mogą być publiczne, prywatne lub chronione,
+   chociaż w praktyce prywatne i chronione są równoważne, ponieważ dziedziczenie nie jest dozwolone.
+  </para>
+
+  <para>Stała enuma może odnosić się do przypadku enuma:</para>
+
+  <programlisting role="php">
+<![CDATA[
+<?php
+
+enum Size
+{
+    case Small;
+    case Medium;
+    case Large;
+
+    public const Huge = self::Large;
+}
+?>
+]]>
+  </programlisting>
+ </sect1>
+
+ <sect1 xml:id="language.enumerations.traits">
+  <title>Traity</title>
+
+  <para>Wyliczenia mogą wykorzystywać cechy, które będą zachowywać się tak samo jak w przypadku klas.
+   Zastrzeżeniem jest to, że traity <literal>używane</literal> w enum nie mogą zawierać właściwości.
+   Mogą one zawierać jedynie metody, metody statyczne i stałe. Traity z właściwościami
+   spowodują błąd krytyczny.
+  </para>
+
+  <programlisting role="php">
+<![CDATA[
+<?php
+
+interface Colorful
+{
+    public function color(): string;
+}
+
+trait Rectangle
+{
+    public function shape(): string {
+        return "Rectangle";
+    }
+}
+
+enum Suit implements Colorful
+{
+    use Rectangle;
+
+    case Hearts;
+    case Diamonds;
+    case Clubs;
+    case Spades;
+
+    public function color(): string
+    {
+        return match($this) {
+            Suit::Hearts, Suit::Diamonds => 'Red',
+            Suit::Clubs, Suit::Spades => 'Black',
+        };
+    }
+}
+?>
+]]>
+  </programlisting>
+ </sect1>
+
+ <sect1 xml:id="language.enumerations.expressions">
+  <title>Wartości Enum w wyrażeniach stałych</title>
+
+  <para>
+   Ponieważ case są reprezentowane jako stałe w samym wyliczeniu, mogą być używane jako wartości
+   statyczne w większości wyrażeń stałych: wartości domyślne właściwości, wartości domyślne zmiennych
+   statycznych, wartości domyślne parametrów, wartości stałe globalne i klasowe. Nie mogą być używane
+   w innych wartościach case wyliczenia, ale normalne stałe mogą odnosić się do case wyliczenia.
+  </para>
+
+  <para>
+   Jednak niejawne magiczne wywołania metod, takie jak <classname>ArrayAccess</classname> na enumach, 
+   nie są dozwolone w definicjach statycznych lub stałych, ponieważ nie można absolutnie zagwarantować, że
+   wynikowa wartość jest deterministyczna lub że wywołanie metody jest wolne od skutków ubocznych. Wywołania
+   funkcji, metod i dostęp do właściwości nadal są nieprawidłowymi operacjami w stałych wyrażeniach.
+  </para>
+
+  <programlisting role="php">
+<![CDATA[
+<?php
+
+// Jest to całkowicie legalna definicja Enum.
+enum Direction implements ArrayAccess
+{
+    case Up;
+    case Down;
+
+    public function offsetExists($offset): bool
+    {
+        return false;
+    }
+
+    public function offsetGet($offset): mixed
+    {
+        return null;
+    }
+
+    public function offsetSet($offset, $value): void
+    {
+        throw new Exception();
+    }
+
+    public function offsetUnset($offset): void
+    {
+        throw new Exception();
+    }
+}
+
+class Foo
+{
+    // This is allowed.
+    const DOWN = Direction::Down;
+
+    // Jest to niedozwolone, ponieważ może nie być deterministyczne.
+    const UP = Direction::Up['short'];
+    // Błąd krytyczny: Nie można użyć [] na wyliczeniach w wyrażeniu stałym
+}
+
+// Jest to całkowicie legalne, ponieważ nie jest to wyrażenie stałe.
+$x = Direction::Up['short'];
+var_dump("\$x is " . var_export($x, true));
+
+$foo = new Foo();
+?>
+]]>
+  </programlisting>
+ </sect1>
+
+ <sect1 xml:id="language.enumerations.object-differences">
+  <title>Różnice w stosunku do obiektów</title>
+
+  <para>
+   Chociaż enumy są zbudowane na klasach i obiektach, nie obsługują wszystkich funkcji związanych z obiektami.
+   W szczególności case Enuma nie mogą posiadać stanu.
+  </para>
+
+  <simplelist>
+   <member>Konstruktory i Destruktory są zabronione.</member>
+   <member>Dziedziczenie nie jest obsługiwane. Wyliczenia nie mogą rozszerzać ani być rozszerzane.</member>
+   <member>Właściwości statyczne lub obiektowe nie są dozwolone.</member>
+   <member>Klonowanie przypadku Enum nie jest obsługiwane, ponieważ przypadki muszą być pojedynczymi instancjami.</member>
+   <member><link linkend="language.oop5.magic">Metody magiczne</link>z wyjątkiem tych wymienionych poniżej są niedozwolone.</member>
+   <member>Enumy muszą być zawsze zadeklarowane przed ich użyciem.</member>
+  </simplelist>
+
+  <para>Następujące funkcje obiektu są dostępne i zachowują się tak samo, jak w przypadku każdego innego obiektu:</para>
+
+  <simplelist>
+   <member>Metody publiczne, prywatne i chronione.</member>
+   <member>Publiczne, prywatne i chronione metody statyczne.</member>
+   <member>Stałe publiczne, prywatne i chronione</member>
+   <member>Enum może implementować dowolną liczbę interfejsów.</member>
+   <member>
+    Enumy i przypadki mogą mieć dołączone <link linkend="language.attributes">atrybuty</link>.
+    Filtr docelowy <constant>TARGET_CLASS</constant>
+    obejmuje same wyliczenia. Filtr docelowy <constant>TARGET_CLASS_CONST</constant>
+    obejmuje przypadki Enumów.
+   </member>
+   <member>
+    Magiczn metody <link linkend="object.call">__call</link>, <link linkend="object.callstatic">__callStatic</link>,
+    i <link linkend="object.invoke">__invoke</link>
+   </member>
+   <member><constant>__CLASS__</constant> i <constant>__FUNCTION__</constant> stałe zachowują się jak zwykle</member>
+  </simplelist>
+
+  <para>
+   Stała magiczna <literal>::class</literal> na typie Enum jest oceniana na nazwę typu,
+   w tym dowolną przestrzeń nazw, dokładnie tak samo jak obiekt. Stała magiczna <literal>::class</literal>
+   na instancji Case również jest wartościowana na typ Enum, ponieważ jest
+   instancją tego typu.
+  </para>
+
+  <para>
+   Dodatkowo case enuma nie mogą być instancjonowane bezpośrednio za pomocą <literal>new</literal>, ani za pomocą
+   <methodname>ReflectionClass::newInstanceWithoutConstructor</methodname> w refleksji. W obu przypadkach wystąpi błąd.
+  </para>
+
+  <programlisting role="php">
+<![CDATA[
+<?php
+
+$clovers = new Suit();
+// Błąd: Nie można utworzyć instancji enum Suit
+
+$horseshoes = (new ReflectionClass(Suit::class))->newInstanceWithoutConstructor()
+// Błąd: Nie można utworzyć instancji enum Suit
+?>
+]]>
+  </programlisting>
+ </sect1>
+
+ <sect1 xml:id="language.enumerations.listing">
+  <title>Wykaz wartości</title>
+
+  <para>
+   Zarówno Pure Enums, jak i Backed Enums implementują wewnętrzny interfejs o nazwie
+   <interfacename>UnitEnum</interfacename>. <literal>UnitEnum</literal> zawiera statyczną metodę
+   <literal>cases()</literal>. <literal>cases()</literal> returns a packed array of
+   zwraca spakowaną tablicę wszystkich zdefiniowanych Cases w kolejności deklaracji.
+  </para>
+
+  <programlisting role="php">
+<![CDATA[
+<?php
+
+Suit::cases();
+// Produces: [Suit::Hearts, Suit::Diamonds, Suit::Clubs, Suit::Spades]
+?>
+]]>
+  </programlisting>
+
+  <para>Ręczne zdefiniowanie metody <literal>cases()</literal> na Enum spowoduje błąd krytyczny.</para>
+ </sect1>
+
+ <sect1 xml:id="language.enumerations.serialization">
+  <title>Serializacja</title>
+
+  <para>
+   Wyliczenia są serializowane inaczej niż obiekty. W szczególności mają one nowy kod serializacji,
+   <literal>"E"</literal>, który określa nazwę case enuma. Procedura deserializacji może następnie
+   użyć tego do ustawienia zmiennej na istniejącą pojedynczą wartość. Zapewnia to, że:
+  </para>
+
+  <programlisting role="php">
+<![CDATA[
+<?php
+
+Suit::Hearts === unserialize(serialize(Suit::Hearts));
+
+print serialize(Suit::Hearts);
+// E:11:"Suit:Hearts";
+?>
+]]>
+  </programlisting>
+
+  <para>
+   Podczas deserializacji, jeśli nie można znaleźć enuma i case pasującego do zserializowanej
+   wartości, zostanie wyświetlone ostrzeżenie i zwrócone &false;.</para>
+
+  <para>
+   Jeśli Pure Enum jest serializowane do JSON, zostanie zgłoszony błąd. Jeśli Backed Enum
+   jest serializowane do JSON, będzie reprezentowane tylko przez jego wartość skalarną
+   w odpowiednim typie. Zachowanie obu może zostać zastąpione przez implementację
+   <classname>JsonSerializable</classname>.
+  </para>
+
+  <para>Dla <function>print_r</function>, wynik case enuma jest nieco inny
+   niż obiektów, aby zminimalizować zamieszanie.
+  </para>
+
+  <programlisting role="php">
+<![CDATA[
+<?php
+
+enum Foo {
+    case Bar;
+}
+
+enum Baz: int {
+    case Beep = 5;
+}
+
+print_r(Foo::Bar);
+print_r(Baz::Beep);
+
+/* Produkuje
+
+Foo Enum (
+    [name] => Bar
+)
+Baz Enum:int {
+    [name] => Beep
+    [value] => 5
+}
+*/
+?>
+]]>
+  </programlisting>
+ </sect1>
+
+ <sect1 xml:id="language.enumerations.object-differences.inheritance">
+
+  <title>Dlaczego enumy nie są rozszerzalne</title>
+
+  <simpara>
+   Klasy mają umowy dotyczące swoich metod:
+  </simpara>
+
+  <programlisting role="php">
+<![CDATA[
+<?php
+
+class A {}
+class B extends A {}
+
+function foo(A $a) {}
+
+function bar(B $b) {
+    foo($b);
+}
+?>
+]]>
+ </programlisting>
+
+  <simpara>
+   Ten kod jest bezpieczny dla typów, ponieważ B podąża za kontraktem A, a dzięki magii
+   współbieżności/kontrawariancji, wszelkie oczekiwania, jakie można mieć wobec metod,
+   zostaną zachowane, z wyjątkiem wyjątków.
+  </simpara>
+
+  <simpara>
+   Enumy mają kontrakty dotycząc case, a nie metody:
+  </simpara>
+
+  <programlisting role="php">
+<![CDATA[
+<?php
+
+enum ErrorCode {
+    case SOMETHING_BROKE;
+}
+
+function quux(ErrorCode $errorCode)
+{
+    // Po napisaniu kod ten wydaje się obejmować wszystkie przypadki
+    match ($errorCode) {
+        ErrorCode::SOMETHING_BROKE => true,
+    };
+}
+
+?>
+]]>
+  </programlisting>
+
+  <simpara>
+   Instrukcja &match; w funkcji <code>quux</code> może być analizowana statycznie, aby objąć
+   wszystkie przypadki w ErrorCode.
+  </simpara>
+
+  <simpara>
+   Ale wyobraźmy sobie, że można rozszerzyć enumy:
+  </simpara>
+
+
+  <programlisting role="php">
+<![CDATA[
+<?php
+
+// Kod eksperymentu myślowego, w którym wyliczenia nie są ostateczne.
+// Uwaga, to nie będzie działać w PHP.
+enum MoreErrorCode extends ErrorCode {
+    case PEBKAC;
+}
+
+function fot(MoreErrorCode $errorCode) {
+    quux($errorCode);
+}
+
+fot(MoreErrorCode::PEBKAC);
+
+?>
+]]>
+ </programlisting>
+
+  <simpara>
+   Zgodnie z normalnymi zasadami dziedziczenia, klasa, która rozszerza inną, przejdzie
+   kontrolę typu.
+  </simpara>
+
+  <simpara>
+   Problemem byłoby to, że instrukcja &match; w <code>quux()</code> nie obejmuje już wszystkich
+   case. Ponieważ nie wie o <code>MoreErrorCode::PEBKAC</code> match zgłosi wyjątek.
+  </simpara>
+
+  <simpara>
+   Z tego powodu wyliczenia są ostateczne i nie mogą być rozszerzane.
+  </simpara>
+ </sect1>
+
+ <sect1 xml:id="language.enumerations.examples">
+  &reftitle.examples;
+
+  <para>
+   <example>
+    <title>Podstawowe wartości ograniczone</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+enum SortOrder
+{
+    case Asc;
+    case Desc;
+}
+
+function query($fields, $filter, SortOrder $order = SortOrder::Asc)
+{
+     /* ... */
+}
+?>
+]]>
+    </programlisting>
+    <para>
+     Funkcja <literal>query()</literal> może teraz działać bezpiecznie, wiedząc, że
+     <literal>$order</literal> jest gwarantowane jako <literal>SortOrder::Asc</literal>
+     lub <literal>SortOrder::Desc</literal>. Każda inna wartość spowodowałaby błąd
+     <classname>TypeError</classname>, więc nie jest potrzebne dalsze sprawdzanie błędów ani testowanie.
+    </para>
+   </example>
+  </para>
+
+  <para>
+
+   <example>
+    <title>Zaawansowane wyłączne wartości</title>
+
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+enum UserStatus: string
+{
+    case Pending = 'P';
+    case Active = 'A';
+    case Suspended = 'S';
+    case CanceledByUser = 'C';
+
+    public function label(): string
+    {
+        return match($this) {
+            self::Pending => 'Pending',
+            self::Active => 'Active',
+            self::Suspended => 'Suspended',
+            self::CanceledByUser => 'Canceled by user',
+        };
+    }
+}
+?>
+]]>
+    </programlisting>
+
+    <para>
+     W tym przykładzie status użytkownika może być jednym z, i wyłącznie <literal>UserStatus::Pending</literal>,
+     <literal>UserStatus::Active</literal>, <literal>UserStatus::Suspended</literal>, lub
+     <literal>UserStatus::CanceledByUser</literal>. Funkcja może wpisać parametr względem
+     <literal>UserStatus</literal> a następnie zaakceptować tylko te cztery wartości.
+    </para>
+
+    <para>
+     Wszystkie cztery wartości mają metodę <literal>label()</literal>, która zwraca ciąg znaków czytelny dla człowieka.
+     Ciąg ten jest niezależny od skalarnego odpowiednika ciągu "machine name", który może być użyty na przykład
+     w polu bazy danych lub polu wyboru HTML.
+    </para>
+
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+foreach (UserStatus::cases() as $case) {
+    printf('<option value="%s">%s</option>\n', $case->value, $case->label());
+}
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+
+ </sect1>
+
+ </chapter>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/language/fibers.xml
+++ b/language/fibers.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 376d3f9c2ef7fcd64d8b8503d552013acefb8b5b Maintainer: grzesiek Status: ready -->
+<!-- $Revision$ -->
+<chapter xml:id="language.fibers" xmlns="http://docbook.org/ns/docbook">
+ <title>Fibers</title>
+
+ <simplesect xml:id="language.fibers.overview">
+  <title>Przegląd fiberów</title>
+  <?phpdoc print-version-for="fiber"?>
+  <para>
+   Fibery reprezentują pełnostosowe, przerywalne funkcje. Fibery mogą być zawieszane z dowolnego miejsca
+   w stosie wywołań, wstrzymując wykonywanie w ramach fiber do momentu wznowienia fiber w późniejszym czasie.
+  </para>
+  <para>
+   Fibery wstrzymują cały stos wykonawczy, więc bezpośredni wywołujący funkcję nie musi zmieniać
+   sposobu jej wywoływania.
+  </para>
+  <para>
+   Wykonanie może zostać przerwane w dowolnym miejscu stosu wywołań przy użyciu <methodname>Fiber::suspend</methodname>
+   (oznacz to, że wywołanie <methodname>Fiber::suspend</methodname> może znajdować się w głęboko zagnieżdżonej funkcji
+   lub w ogóle nie istnieć).
+  </para>
+  <para>
+   W przeciwieństwie do bezstosowych <classname>Generatorów</classname>, każdy <classname>Fiber</classname> ma swój własny stos wywołań,
+   co pozwala na ich wstrzymywanie w ramach głęboko zagnieżdżonych wywołań funkcji. Funkcja deklarująca punkt przerwania
+   (czyli wywołująca <methodname>Fiber::suspend</methodname>) nie musi zmieniać swojego typu zwracanego, w przeciwieństwie do funkcji używającej
+   &yield; która musi zwracać instancję <classname>Generator</classname>.
+  </para>
+  <para>
+   Fibery można zawiesić w dowolnym wywołaniu funkcji, w tym tych wywoływanych z poziomu maszyny wirtualnej PHP, takich jak funkcje
+   przekazywane do <function>array_map</function> lub metody wywoływane przez &foreach; na obiekcie
+   <classname>Iterator</classname>.
+  </para>
+  <para>
+   Po zawieszeniu, wykonywanie fiber może zostać wznowione z dowolną wartością przy użyciu <methodname>Fiber::resume</methodname>
+   lub poprzez rzucenie wyjątku do fiber przy użyciu <methodname>Fiber::throw</methodname>. Wartość jest zwracana
+   (lub rzucany jest wyjątek) z <methodname>Fiber::suspend</methodname>.
+  </para>
+  <note>
+   <simpara>
+    Przed PHP 8.4.0, przełączanie fiber podczas wykonywania obiektu
+    <link linkend="language.oop5.decon.destructor">destructor</link> nie było
+    dozwolone.
+   </simpara>
+  </note> 
+
+  <example xml:id="language.fiber.example.basic"><!-- {{{ -->
+   <title>Podstawowe użycie</title>
+   <programlisting role="php">
+    <![CDATA[
+<?php
+$fiber = new Fiber(function (): void {
+   $value = Fiber::suspend('fiber');
+   echo "Value used to resume fiber: ", $value, PHP_EOL;
+});
+
+$value = $fiber->start();
+
+echo "Value from fiber suspending: ", $value, PHP_EOL;
+
+$fiber->resume('test');
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+    <![CDATA[
+Value from fiber suspending: fiber
+Value used to resume fiber: test
+]]>
+   </screen>
+  </example><!-- }}} -->
+
+ </simplesect>
+
+</chapter>
+ 
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/language/generators.xml
+++ b/language/generators.xml
@@ -1,0 +1,606 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 08e58ace7e5b538c8ed75d784a54885d5f785d30 Maintainer: grzesiek Status: ready -->
+<!-- $Revision$ -->
+<chapter xml:id="language.generators" xmlns="http://docbook.org/ns/docbook">
+ <title>Generators</title>
+
+ <sect1 xml:id="language.generators.overview">
+  <title>Przegląd generatorów</title>
+  <?phpdoc print-version-for="generators"?>
+
+  <para>
+   Generatory zapewniają łatwy sposób implementacji prostych 
+   <link linkend="language.oop5.iterations">iteratorów</link> without the
+   bez narzutu lub złożoności implementacji klasy, która implementuje interfejs
+   <classname>Iterator</classname>.
+  </para>
+
+  <para>
+   Generator oferuje wygodny sposób dostarczania danych do pętli &foreach; bez konieczności
+   budowania tablicy w pamięci z wyprzedzeniem, co może spowodować przekroczenie limitu pamięci
+   przez program lub wymagać znacznej ilości czasu przetwarzania w celu wygenerowania.
+   Zamiast tego można użyć funkcji generatora,
+   która jest taka sama jak zwykła
+   <link linkend="functions.user-defined">funkcja</link>, z tym wyjątkiem,
+   że zamiast
+   <link linkend="functions.returning-values">zwracać</link>raz,
+   generator może &yield; tyle razy, ile potrzebuje, aby dostarczyć
+   wartości do iteracji.
+   Podobnie jak w przypadku iteratorów, losowy dostęp do danych nie jest możliwy.
+  </para>
+
+  <para>
+   Prostym tego przykładem jest ponowne zaimplementowanie funkcji <function>range</function>
+   jako generatora. Standardowa funkcja <function>range</function>
+   musi wygenerować tablicę z każdą wartością i zwrócić ją, co może
+   skutkować dużymi tablicami: na przykład wywołanie
+   <command>range(0, 1000000)</command> spowoduje użycie ponad
+   100 MB pamięci.
+  </para>
+
+  <para>
+   Alternatywnie, możemy zaimplementować generator <literal>xrange()</literal>,
+   który będzie potrzebował tylko tyle pamięci, aby utworzyć obiekt
+   <classname>Iterator</classname> i śledzenia bieżącego stanu
+   generatora wewnętrznie, co okazuje się być mniej niż 1 kilobajt..
+  </para>
+
+  <example>
+   <title>Implementowanie <function>range</function> jako generator</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+function xrange($start, $limit, $step = 1) {
+    if ($start <= $limit) {
+        if ($step <= 0) {
+            throw new LogicException('Step must be positive');
+        }
+
+        for ($i = $start; $i <= $limit; $i += $step) {
+            yield $i;
+        }
+    } else {
+        if ($step >= 0) {
+            throw new LogicException('Step must be negative');
+        }
+
+        for ($i = $start; $i >= $limit; $i += $step) {
+            yield $i;
+        }
+    }
+}
+
+/*
+ * Zauważ, że zarówno range() jak i xrange() dają ten sam
+ * wynik poniżej.
+ */
+
+echo 'Single digit odd numbers from range():  ';
+foreach (range(1, 9, 2) as $number) {
+    echo "$number ";
+}
+echo "\n";
+
+echo 'Single digit odd numbers from xrange(): ';
+foreach (xrange(1, 9, 2) as $number) {
+    echo "$number ";
+}
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+Single digit odd numbers from range():  1 3 5 7 9
+Single digit odd numbers from xrange(): 1 3 5 7 9
+]]>
+   </screen>
+  </example>
+
+  <sect2 xml:id="language.generators.object">
+   <title>Obiekty <classname>Generator</classname></title>
+   <para>
+    Po wywołaniu funkcji generatora zwracany jest nowy obiekt wewnętrznej klasy
+    <classname>Generator</classname>. Obiekt ten implementuje interfejs
+    <classname>Iterator</classname> w taki sam sposób, jak obiekt iteratora
+    typu forward-only i udostępnia metody, które mogą być
+    wywoływane w celu manipulowania stanem generatora, w tym wysyłania do niego
+    wartości i zwracania z niego wartości.
+   </para>
+  </sect2>
+ </sect1>
+
+ <sect1 xml:id="language.generators.syntax">
+  <title>Składnia generatora</title>
+
+  <para>
+   Funkcja generatora wygląda jak zwykła funkcja, z tą różnicą, że zamiast zwracać wartość,
+   instrukcja generatora &yield; zwraca tyle wartości, ile potrzebuje.
+   Każda funkcja zawierająca &yield; jest funkcją generatora.
+  </para>
+
+  <para>
+   Gdy wywoływana jest funkcja generatora, zwraca ona obiekt, nad którym
+   można iterować. Podczas iteracji nad tym obiektem (na przykład za pomocą pętli
+   &foreach;), PHP wywoła metody iteracyjne obiektu za każdym razem, gdy będzie potrzebować
+   wartości, a następnie zapisze stan generatora, gdy generator zwróci wartość,
+   aby można go było wznowić, gdy wymagana jest następna wartość.
+  </para>
+
+  <para>
+   Gdy nie ma już więcej wartości do zwrócenia, generator
+   może po prostu powrócić, a kod wywołujący jest kontynuowany tak,
+   jakby skończyły się wartości tablicy.
+  </para>
+
+  <note>
+   <para>
+    Generator może zwracać wartości, które mogą być pobierane za pomocą
+    <methodname>Generator::getReturn</methodname>.
+   </para>
+  </note>
+
+  <sect2 xml:id="control-structures.yield">
+   <title><command>yield</command> keyword</title>
+
+   <para>
+    Sercem funkcji generatora jest słowo kluczowe <command>yield</command>.
+    W swojej najprostszej formie, instrukcja yield wygląda podobnie
+    do instrukcji return, z tą różnicą, że zamiast zatrzymywać wykonywanie funkcji i
+    powracać, yield zamiast tego dostarcza wartość do kodu pętli nad generatorem i
+    wstrzymuje wykonywanie funkcji generatora.
+   </para>
+
+   <example>
+    <title>Prosty przykład zwracania wartości</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+function gen_one_to_three() {
+    for ($i = 1; $i <= 3; $i++) {
+        // Zauważ, że $i jest zachowywane pomiędzy yieldami.
+        yield $i;
+    }
+}
+
+$generator = gen_one_to_three();
+foreach ($generator as $value) {
+    echo "$value\n";
+}
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+1
+2
+3
+]]>
+    </screen>
+   </example>
+
+   <note>
+    <para>
+     Wewnętrznie, sekwencyjne klucze całkowite zostaną sparowane z zwracanymi
+     wartościami, tak jak w przypadku tablicy nieasocjacyjnej.
+    </para>
+   </note>
+
+   <sect3 xml:id="control-structures.yield.associative">
+    <title>Zwracanie wartości z kluczami</title>
+
+    <para>
+     PHP również obsługuje tablice asocjacyjne, a generatory niczym się od nich nie różnią.
+     Oprócz zwracania prostych wartości, jak pokazano powyżej, można również zwracać
+     klucz w tym samym czasie.
+    </para>
+
+    <para>
+     Składnia do zwracania pary klucz/wartość jest bardzo podobna do tej używanej do
+     definiowania tablicy asocjacyjnej, jak pokazano poniżej.
+    </para>
+
+    <example>
+     <title>Zwracanie pary klucz/wartość</title>
+     <programlisting role="php">
+<![CDATA[
+<?php
+/*
+ * Dane wejściowe to pola oddzielone średnikami, przy czym pierwsze
+ * pole to identyfikator używany jako klucz.
+ */
+
+$input = <<<'EOF'
+1;PHP;Likes dollar signs
+2;Python;Likes whitespace
+3;Ruby;Likes blocks
+EOF;
+
+function input_parser($input) {
+    foreach (explode("\n", $input) as $line) {
+        $fields = explode(';', $line);
+        $id = array_shift($fields);
+
+        yield $id => $fields;
+    }
+}
+
+foreach (input_parser($input) as $id => $fields) {
+    echo "$id:\n";
+    echo "    $fields[0]\n";
+    echo "    $fields[1]\n";
+}
+?>
+]]>
+     </programlisting>
+     &example.outputs;
+     <screen>
+<![CDATA[
+1:
+    PHP
+    Likes dollar signs
+2:
+    Python
+    Likes whitespace
+3:
+    Ruby
+    Likes blocks
+]]>
+     </screen>
+    </example>
+   </sect3>
+
+   <sect3 xml:id="control-structures.yield.null">
+    <title>Zwracanie wartości null</title>
+
+    <para>
+     Yield można wywołać bez argumentu, aby zwrócić wartość &null; z
+     automatycznym kluczem.
+    </para>
+
+    <example>
+     <title>Zwracanie &null;</title>
+     <programlisting role="php">
+<![CDATA[
+<?php
+function gen_three_nulls() {
+    foreach (range(1, 3) as $i) {
+        yield;
+    }
+}
+
+var_dump(iterator_to_array(gen_three_nulls()));
+?>
+]]>
+     </programlisting>
+     &example.outputs;
+     <screen>
+<![CDATA[
+array(3) {
+  [0]=>
+  NULL
+  [1]=>
+  NULL
+  [2]=>
+  NULL
+}
+]]>
+     </screen>
+    </example>
+   </sect3>
+
+   <sect3 xml:id="control-structures.yield.references">
+    <title>Zwracanie przez referencję</title>
+
+    <para>
+     Funkcje generatora są w stanie zwrócić wartości przez odniesienie, jak również przez
+     wartość. Odbywa się to w taki sam sposób jak
+     <link linkend="functions.returning-values">zwracanie referencji z funkcji</link>:
+     poprzez dodanie znaku ampersand do nazwy funkcji.
+    </para>
+
+    <example>
+     <title>Zwracanie wartości przez referencję</title>
+     <programlisting role="php">
+<![CDATA[
+<?php
+function &gen_reference() {
+    $value = 3;
+
+    while ($value > 0) {
+        yield $value;
+    }
+}
+
+/*
+ * Zauważ, że możemy zmienić $number wewnątrz pętli, i
+ * ponieważ generator zwraca referencje, $value
+ * w gen_reference() ulega zmianie.
+ */
+foreach (gen_reference() as &$number) {
+    echo (--$number).'... ';
+}
+?>
+]]>
+     </programlisting>
+     &example.outputs;
+     <screen>
+<![CDATA[
+2... 1... 0...
+]]>
+     </screen>
+    </example>
+   </sect3>
+
+   <sect3 xml:id="control-structures.yield.from">
+    <title>Delegacja generatora poprzez <command>yield from</command></title>
+
+    <para>
+     Delegacja generatora pozwala na uzyskanie wartości z innego
+     generatora, obiektu <classname>Traversable</classname> lub
+     <type>tablicy</type> za pomocą słowa kluczowego <command>yield from</command>.
+     Zewnętrzny generator zwróci następnie wszystkie wartości z wewnętrznego generatora,
+     obiektu lub tablicy, dopóki nie przestaną one być ważne, po czym wykonanie
+     będzie kontynuowane w zewnętrznym generatorze.
+    </para>
+
+    <para>
+     Jeśli generator jest używany z <command>yield from</command>, wyrażenie
+     <command>yield from</command> zwróci również każdą wartość zwróconą
+     przez wewnętrzny generator.
+    </para>
+
+    <caution>
+     <title>Zapisywanie do tablicy (np. za pomocą funkcji <function>iterator_to_array</function>)</title>
+
+      <para>
+       <command>yield from</command> nie resetuje kluczy. Zachowuje
+       klucze zwrócone przez obiekt <classname>Traversable</classname> lub
+       <type>tablicę</type>. Tak więc niektóre wartości mogą mieć wspólny klucz z innym
+       <command>yield</command> lub <command>yield from</command>, który po
+       wstawieniu do tablicy nadpisze poprzednie wartości tym kluczem.
+      </para>
+
+      <para>
+       Częstym przypadkiem, w którym ma to znaczenie jest funkcja <function>iterator_to_array</function>
+       zwracająca domyślnie tablicę z kluczem, co może prowadzić do nieoczekiwanych wyników.
+       <function>iterator_to_array</function> ma drugi parametr
+       <parameter>preserve_keys</parameter> który można ustawić na &false;, aby zebrać
+       wszystkie wartości, ignorując klucze zwrócone przez  <classname>Generator</classname>.
+      </para>
+
+      <example>
+       <title><command>yield from</command> z <function>iterator_to_array</function></title>
+       <programlisting role="php">
+<![CDATA[
+<?php
+function inner() {
+    yield 1; // key 0
+    yield 2; // key 1
+    yield 3; // key 2
+}
+function gen() {
+    yield 0; // key 0
+    yield from inner(); // keys 0-2
+    yield 4; // key 1
+}
+// przekazane false jako drugi parametr, aby uzyskać tablicę [0, 1, 2, 3, 4]
+var_dump(iterator_to_array(gen()));
+?>
+]]>
+       </programlisting>
+       &example.outputs;
+       <screen>
+<![CDATA[
+array(3) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(4)
+  [2]=>
+  int(3)
+}
+]]>
+       </screen>
+      </example>
+    </caution>
+
+    <example>
+     <title>Podstawowe użycie <command>yield from</command></title>
+     <programlisting role="php">
+<![CDATA[
+<?php
+function count_to_ten() {
+    yield 1;
+    yield 2;
+    yield from [3, 4];
+    yield from new ArrayIterator([5, 6]);
+    yield from seven_eight();
+    yield 9;
+    yield 10;
+}
+
+function seven_eight() {
+    yield 7;
+    yield from eight();
+}
+
+function eight() {
+    yield 8;
+}
+
+foreach (count_to_ten() as $num) {
+    echo "$num ";
+}
+?>
+]]>
+     </programlisting>
+     &example.outputs;
+     <screen>
+<![CDATA[
+1 2 3 4 5 6 7 8 9 10
+]]>
+     </screen>
+    </example>
+
+    <example>
+     <title><command>yield from</command> i zwracane wartości</title>
+     <programlisting role="php">
+<![CDATA[
+<?php
+function count_to_ten() {
+    yield 1;
+    yield 2;
+    yield from [3, 4];
+    yield from new ArrayIterator([5, 6]);
+    yield from seven_eight();
+    return yield from nine_ten();
+}
+
+function seven_eight() {
+    yield 7;
+    yield from eight();
+}
+
+function eight() {
+    yield 8;
+}
+
+function nine_ten() {
+    yield 9;
+    return 10;
+}
+
+$gen = count_to_ten();
+foreach ($gen as $num) {
+    echo "$num ";
+}
+echo $gen->getReturn();
+?>
+]]>
+     </programlisting>
+     &example.outputs;
+     <screen>
+<![CDATA[
+1 2 3 4 5 6 7 8 9 10
+]]>
+     </screen>
+    </example>
+   </sect3>
+  </sect2>
+ </sect1>
+
+ <sect1 xml:id="language.generators.comparison">
+  <title>Porównanie generatorów z obiektami <classname>Iterator</classname></title>
+
+  <para>
+   Podstawową zaletą generatorów jest ich prostota. W porównaniu
+   do implementacji klasy <classname>Iterator</classname> należy napisać znacznie
+   mniej standardowego kodu, a kod jest ogólnie bardziej czytelny.
+   readable. Na przykład, poniższa funkcja i klasa są równoważne:
+  </para>
+
+  <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
+function getLinesFromFile($fileName) {
+    if (!$fileHandle = fopen($fileName, 'r')) {
+        return;
+    }
+
+    while (false !== $line = fgets($fileHandle)) {
+        yield $line;
+    }
+
+    fclose($fileHandle);
+}
+
+// kontra...
+
+class LineIterator implements Iterator {
+    protected $fileHandle;
+
+    protected $line;
+    protected $i;
+
+    public function __construct($fileName) {
+        if (!$this->fileHandle = fopen($fileName, 'r')) {
+            throw new RuntimeException('Couldn\'t open file "' . $fileName . '"');
+        }
+    }
+
+    public function rewind() {
+        fseek($this->fileHandle, 0);
+        $this->line = fgets($this->fileHandle);
+        $this->i = 0;
+    }
+
+    public function valid() {
+        return false !== $this->line;
+    }
+
+    public function current() {
+        return $this->line;
+    }
+
+    public function key() {
+        return $this->i;
+    }
+
+    public function next() {
+        if (false !== $this->line) {
+            $this->line = fgets($this->fileHandle);
+            $this->i++;
+        }
+    }
+
+    public function __destruct() {
+        fclose($this->fileHandle);
+    }
+}
+?>
+]]>
+   </programlisting>
+  </informalexample>
+
+  <para>
+   Ta elastyczność ma jednak swoją cenę: generatory są iteratorami tylko do przodu
+   i nie można ich przewinąć po rozpoczęciu iteracji. Oznacza to również,
+   że ten sam generator nie może być iterowany wielokrotnie:
+   generator będzie musiał zostać odbudowany poprzez ponowne wywołanie funkcji generatora.
+  </para>
+
+  <simplesect role="seealso">
+   &reftitle.seealso;
+   <para>
+    <simplelist>
+     <member><link linkend="language.oop5.iterations">Iteracja obiektu</link></member>
+    </simplelist>
+   </para>
+  </simplesect>
+
+ </sect1>
+</chapter>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/language/namespaces.xml
+++ b/language/namespaces.xml
@@ -1,0 +1,1567 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: f4f96ef8b2a95283c92ea2183fe1dedf06f3ad22 Maintainer: grzesiek Status: ready -->
+<!-- $Revision$ -->
+<chapter xml:id="language.namespaces" xmlns="http://docbook.org/ns/docbook"
+ version="1.1">
+ <title>Przestrzenie nazw</title>
+
+ <sect1 xml:id="language.namespaces.rationale">
+  <title>Przegląd przestrzeni nazw</title>
+  <titleabbrev>Przegląd</titleabbrev>
+  <?phpdoc print-version-for="namespaces"?>
+  <simpara>
+   Czym są przestrzenie nazw? W najszerszej definicji przestrzenie nazw są sposobem enkapsulacji
+   elementów. Może to być postrzegane jako abstrakcyjna koncepcja w wielu miejscach. Na przykład w każdym
+   ystemie operacyjnym katalogi służą do grupowania powiązanych plików i działają jako przestrzeń
+   nazw dla plików w nich zawartych. Jako konkretny przykład, plik <literal>foo.txt</literal> może
+   może istnieć zarówno w katalogu <literal>/home/greg</literal> jak i w <literal>/home/other</literal>,
+   ale dwie kopie <literal>foo.txt</literal> nie mogą współistnieć w tym samym katalogu. Ponadto,
+   aby uzyskać dostęp do pliku <literal>foo.txt</literal> poza katalogiem
+   <literal>/home/greg</literal> musimy dodać nazwę katalogu do nazwy pliku za pomocą
+   separatora katalogów, aby uzyskać <literal>/home/greg/foo.txt</literal>. Ta sama zasada
+   rozciąga się na przestrzenie nazw w świecie programowania.
+  </simpara>
+
+  <simpara>
+   W świecie PHP przestrzenie nazw zostały zaprojektowane w celu rozwiązania dwóch problemów,
+   które napotykają autorzy bibliotek i aplikacji podczas tworzenia elementów kodu wielokrotnego użytku,
+   takich jak klasy lub funkcje:
+  </simpara>
+  <para>
+   <orderedlist>
+    <listitem>
+     <simpara>
+      Kolizje nazw między tworzonym kodem a wewnętrznymi
+      klasami/funkcjami/stałymi PHP lub klasami/funkcjami/stałymi innych firm.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      Możliwość aliasowania (lub skracania) Extra_Long_Names ma na celu złagodzenie pierwszego problemu,
+      poprawiając czytelność kodu źródłowego.
+     </simpara>
+    </listitem>
+   </orderedlist>
+  </para>
+  <simpara>
+   Przestrzenie nazw PHP umożliwiają grupowanie powiązanych klas, interfejsów,
+   funkcji i stałych. Oto przykład składni przestrzeni nazw w PHP:
+  </simpara>
+  <example>
+   <title>Przykład składni przestrzeni nazw</title>
+   <programlisting role="php">
+   <![CDATA[
+<?php
+namespace my\name; // zobacz sekcję "Definiowanie Przestrzeni Nazw"
+
+class MyClass {}
+function myfunction() {}
+const MYCONST = 1;
+
+$a = new MyClass;
+$c = new \my\name\MyClass; // zobacz sekcję "Przestrzeń Globalna"
+
+$a = strlen('hi'); // see "Using namespaces: fallback to global
+                   // function/constant" section
+
+$d = namespace\MYCONST; // zobacz sekcję "operator przestrzeni nazw i stała
+                        // __NAMESPACE__"
+$d = __NAMESPACE__ . '\MYCONST';
+echo constant($d); // zobacz sekcję "Przestrzenie nazw i dynamiczne funkcje języka"
+?>
+    ]]>
+   </programlisting>
+  </example>
+   <note>
+    <simpara>
+     Wielkość liter w nazwach przestrzeni nazw nie ma znaczenia.
+    </simpara>
+   </note>
+  <note>
+   <para>
+    Nazwa przestrzeni nazw <literal>PHP</literal> i nazwy złożone zaczynające się
+    od tej nazwy (jak <literal>PHP\Classes</literal>) są zarezerwowane do wewnętrznego użytku języka
+    i nie powinny być używane w kodzie przestrzeni użytkownika.
+   </para>
+  </note>
+ </sect1>
+
+ <sect1 xml:id="language.namespaces.definition">
+  <title>Definiowanie przestrzeni nazw</title>
+  <titleabbrev>Przestrzenie nazw</titleabbrev>
+  <?phpdoc print-version-for="namespaces"?>
+  <para>
+   Chociaż każdy poprawny kod PHP może być zawarty w przestrzeni nazw, tylko następujące typy kodu
+   podlegają wpływowi przestrzeni nazw: klasy (w tym abstrakcje i traity), interfejsy, funkcje i stałe.
+  </para>
+  <para>
+   Przestrzenie nazw są deklarowane za pomocą słowa <literal>namespace</literal>
+   Plik zawierający przestrzeń nazw musi zadeklarować przestrzeń nazw na
+   początku pliku przed jakimkolwiek innym kodem - z jednym wyjątkiem:
+   słowem kluczowym <xref linkend="control-structures.declare" />.
+   <example>
+    <title>Deklarowanie pojedynczej przestrzeni nazw</title>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+namespace MyProject;
+
+const CONNECT_OK = 1;
+class Connection { /* ... */ }
+function connect() { /* ... */ }
+
+?>
+]]>
+    </programlisting>
+   </example>
+   <note>
+    <simpara>
+     W pełni kwalifikowane nazwy (tj. nazwy zaczynające się od odwrotnego ukośnika) nie są dozwolone
+     w deklaracjach przestrzeni nazw, ponieważ takie konstrukcje są interpretowane jako względne wyrażenia przestrzeni nazw.
+    </simpara>
+   </note>
+   Jedyną konstrukcją kodu dozwoloną przed deklaracją przestrzeni nazw jest instrukcja
+   <literal>declare</literal> służąca do definiowania kodowania pliku źródłowego.
+   Ponadto żaden kod spoza PHP nie może poprzedzać deklaracji przestrzeni nazw, w tym dodatkowe białe znaki:
+   <example>
+    <title>Deklarowanie pojedynczej przestrzeni nazw</title>
+    <programlisting role="php">
+     <![CDATA[
+<html>
+<?php
+namespace MyProject; // błąd krytyczny - przestrzeń nazw musi być pierwszą instrukcją w skrypcie
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+  <para>
+   Ponadto, w przeciwieństwie do innych konstrukcji PHP, ta sama przestrzeń nazw może być zdefiniowana
+   w wielu plikach, umożliwiając podział zawartości przestrzeni nazw w systemie plików.
+  </para>
+ </sect1>
+ <sect1 xml:id="language.namespaces.nested">
+  <title>Deklarowanie podprzestrzeni nazw</title>
+  <titleabbrev>Podprzestrzenie nazw</titleabbrev>
+  <?phpdoc print-version-for="namespaces"?>
+  <para>
+   Podobnie jak katalogi i pliki, przestrzenie nazw PHP również zawierają możliwość określenia
+   hierarchii nazw przestrzeni nazw. Tak więc, nazwa przestrzeni nazw może być zdefiniowana
+   z podpoziomami:
+   <example>
+    <title>Deklarowanie pojedynczej przestrzeni nazw z hierarchią</title>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+namespace MyProject\Sub\Level;
+
+const CONNECT_OK = 1;
+class Connection { /* ... */ }
+function connect() { /* ... */  }
+
+?>
+]]>
+    </programlisting>
+   </example>
+   Powyższy przykład tworzy stałą <literal>MyProject\Sub\Level\CONNECT_OK</literal>,
+   klasę <literal>MyProject\Sub\Level\Connection</literal> i funkcję
+   <literal>MyProject\Sub\Level\connect</literal>.
+  </para>
+ </sect1>
+ <sect1 xml:id="language.namespaces.definitionmultiple">
+  <title>Definiowanie wielu przestrzeni nazw w tym samym pliku</title>
+  <titleabbrev>Definiowanie wielu przestrzeni nazw w tym samym pliku</titleabbrev>
+  <?phpdoc print-version-for="namespaces"?>
+  <para>
+   W tym samym pliku można również zadeklarować wiele przestrzeni nazw. Istnieją dwie
+   dozwolone składnie.
+  </para>
+  <para>
+   <example>
+    <title>Deklarowanie wielu przestrzeni nazw, prosta składnia kombinacji</title>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+namespace MyProject;
+
+const CONNECT_OK = 1;
+class Connection { /* ... */ }
+function connect() { /* ... */  }
+
+namespace AnotherProject;
+
+const CONNECT_OK = 1;
+class Connection { /* ... */ }
+function connect() { /* ... */  }
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+  <para>
+   Ta składnia nie jest zalecana do łączenia przestrzeni nazw w jednym pliku.
+   Zamiast tego zaleca się użycie alternatywnej składni z nawiasami klamrowymi.
+  </para>
+  <para>
+   <example>
+    <title>Deklarowanie wielu przestrzeni nazw, składnia z nawiasami klamrowymi</title>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+namespace MyProject {
+
+const CONNECT_OK = 1;
+class Connection { /* ... */ }
+function connect() { /* ... */  }
+}
+
+namespace AnotherProject {
+
+const CONNECT_OK = 1;
+class Connection { /* ... */ }
+function connect() { /* ... */  }
+}
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+  <para>
+   Zdecydowanie odradza się łączenie wielu przestrzeni nazw w tym samym pliku.
+   Podstawowym przypadkiem użycia jest łączenie wielu skryptów PHP w tym samym
+   pliku.
+  </para>
+  <para>
+   W celu połączenia globalnego kodu bez przestrzeni nazw z kodem z przestrzenią nazw,
+   obsługiwana jest tylko składnia z nawiasami klamrowymi. Kod globalny powinien być
+   zawarty w instrukcji przestrzeni nazw bez nazwy przestrzeni nazw, jak w:
+   <example>
+    <title>Deklarowanie wielu przestrzeni nazw i kod bez przestrzeni nazw</title>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+namespace MyProject {
+
+const CONNECT_OK = 1;
+class Connection { /* ... */ }
+function connect() { /* ... */  }
+}
+
+namespace { // global code
+session_start();
+$a = MyProject\connect();
+echo MyProject\Connection::start();
+}
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+  <para>
+   Żaden kod PHP nie może istnieć poza nawiasami przestrzeni nazw, z wyjątkiem
+   otwierającej instrukcji declare.
+   <example>
+    <title>Deklarowanie wielu przestrzeni nazw i kod bez przestrzeni nazw</title>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+declare(encoding='UTF-8');
+namespace MyProject {
+
+const CONNECT_OK = 1;
+class Connection { /* ... */ }
+function connect() { /* ... */  }
+}
+
+namespace { // global code
+session_start();
+$a = MyProject\connect();
+echo MyProject\Connection::start();
+}
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </sect1>
+ <sect1 xml:id="language.namespaces.basics">
+  <title>Korzystanie z przestrzeni nazw: Podstawy</title>
+  <titleabbrev>Podstawy</titleabbrev>
+  <?phpdoc print-version-for="namespaces"?>
+  <para>
+   Przed omówieniem korzystania z przestrzeni nazw, ważne jest, aby zrozumieć, w jaki sposób PHP
+   wie, który element przestrzeni nazw jest żądany przez kod. Można dokonać prostej analogii
+   między przestrzeniami nazw PHP a systemem plików. Istnieją trzy sposoby dostępu do pliku w
+   systemie plików:
+   <orderedlist>
+    <listitem>
+     <simpara>
+      Względna nazwa pliku, taka jak <literal>foo.txt</literal>. Jest ona rozwiązana do
+      <literal>currentdirectory/foo.txt</literal>, gdzie <literal>currentdirectory</literal> jest
+      aktualnie zajmowanym katalogiem. Jeśli więc bieżącym katalogiem jest
+      <literal>/home/foo</literal> nazwa zostanie rozwiązana do <literal>/home/foo/foo.txt</literal>.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      Względna nazwa ścieżki, taka jak <literal>subdirectory/foo.txt</literal>. To rozwiązuje do
+      <literal>currentdirectory/subdirectory/foo.txt</literal>.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      Bezwzględna nazwa ścieżki, taka jak <literal>/main/foo.txt</literal>. To rozwiązuje się do
+      <literal>/main/foo.txt</literal>.
+     </simpara>
+    </listitem>
+   </orderedlist>
+   Ta sama zasada może być zastosowana do elementów w PHP. Na
+   przykład, nazwa klasy może być określona na trzy sposoby:
+   <orderedlist>
+    <listitem>
+     <simpara>
+      Niekwalifikowana nazwa lub nazwa klasy bez przedrostka, np.
+      <literal>$a = new foo();</literal> lub
+      <literal>foo::staticmethod();</literal>. Jeśli bieżącą przestrzenią nazw jest
+      <literal>currentnamespace</literal>, to rozwiązuje do
+      <literal>currentnamespace\foo</literal>. Jeśli
+      kod jest kodem globalnym, bez przestrzeni nazw, jest to rozwiązuje do <literal>foo</literal>.
+     </simpara>
+     <simpara>
+      Jedno zastrzeżenie: niewykwalifikowane nazwy funkcji i stałych będą rozwiązywane
+      na globalne funkcje i stałe, jeśli funkcja lub stała z przestrzenią nazw nie jest
+      zdefiniowana. Zobacz <link linkend="language.namespaces.fallback">Używanie przestrzeni
+      nazw: powrót do globalnej funkcji/stałej</link> po szczegóły.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      Nazwa kwalifikowana lub nazwa klasy z prefiksem, np.
+      <literal>$a = new subnamespace\foo();</literal> lub
+      <literal>subnamespace\foo::staticmethod();</literal>. Jeśli bieżącą przestrzenią nazw jest
+      <literal>currentnamespace</literal>, rozwiązuje to do
+      <literal>currentnamespace\subnamespace\foo</literal>. Jeśli
+      kod jest kodem globalnym, bez przestrzeni nazw, to rozwiązuje do <literal>subnamespace\foo</literal>.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      W pełni kwalifikowana nazwa lub nazwa z prefiksem z globalnym operatorem prefiksu,
+      takim jak <literal>$a = new \currentnamespace\foo();</literal> lub
+      <literal>\currentnamespace\foo::staticmethod();</literal>. To zawsze rozwiązuje
+      do dosłownej nazwy określonej w kodzie <literal>currentnamespace\foo</literal>.
+     </simpara>
+    </listitem>
+   </orderedlist>
+  </para>
+  <para>
+   Oto przykład trzech rodzajów składni w rzeczywistym kodzie:
+   <informalexample>
+    <simpara>file1.php</simpara>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+namespace Foo\Bar\subnamespace;
+
+const FOO = 1;
+function foo() {}
+class foo
+{
+    static function staticmethod() {}
+}
+?>
+     ]]>
+    </programlisting>
+    <simpara>file2.php</simpara>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+namespace Foo\Bar;
+include 'file1.php';
+
+const FOO = 2;
+function foo() {}
+class foo
+{
+    static function staticmethod() {}
+}
+
+/* Niekwalifikowana nazwa */
+foo(); // rozwiązuje do funkcji Foo\Bar\foo
+foo::staticmethod(); // rozwiązuje do metody staticmethod, klasy Foo\Bar\foo
+echo FOO; // rozwiązuje do stałej Foo\Bar\FOO
+
+/* Nazwa kwalifikowana */
+subnamespace\foo(); // rozwiązuje do funkcji Foo\Bar\subnamespace\foo
+subnamespace\foo::staticmethod(); // rozwiązuje do klasy Foo\Bar\subnamespace\foo,
+                                  // method staticmethod
+echo subnamespace\FOO; // rozwiązuje do stałej Foo\Bar\subnamespace\FOO
+
+/* W pełni kwalifikowana nazwa */
+\Foo\Bar\foo(); // rozwiązuje do funkcji Foo\Bar\foo
+\Foo\Bar\foo::staticmethod(); // rozwiązuje do metody staticmethod, klasy Foo\Bar\foo
+echo \Foo\Bar\FOO; // rozwiązuje do stałej Foo\Bar\FOO
+?>
+     ]]>
+    </programlisting>
+   </informalexample>
+  </para>
+  <para>
+   Należy pamiętać, że aby uzyskać dostęp do dowolnej globalnej
+   klasy, funkcji lub stałej, można użyć w pełni kwalifikowanej nazwy, takiej jak
+   <function>\strlen</function> lub <classname>\Exception</classname> lub
+   \<constant>INI_ALL</constant>.
+   <example>
+    <title>Dostęp do globalnych klas, funkcji i stałych z przestrzeni nazw</title>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+namespace Foo;
+
+function strlen() {}
+const INI_ALL = 3;
+class Exception {}
+
+$a = \strlen('hi'); // wywołuje globalną funkcję strlen
+$b = \INI_ALL; // uzyskuje dostęp do globalnej stałej INI_ALL
+$c = new \Exception('error'); // tworzy instancję globalnej klasy Exception
+?>
+     ]]>
+    </programlisting>
+   </example>
+  </para>
+ </sect1>
+ <sect1 xml:id="language.namespaces.dynamic">
+  <title>Przestrzenie nazw i dynamiczne funkcje języka</title>
+  <titleabbrev>Przestrzenie nazw i dynamiczne funkcje języka</titleabbrev>
+  <?phpdoc print-version-for="namespaces"?>
+  <para>
+   Na implementację przestrzeni nazw w PHP wpływa jego dynamiczna natura jako języka
+   programowania. Tak więc, aby przekonwertować kod taki jak poniższy przykład na kod z przestrzenią nazw:
+   <example>
+    <title>Dynamiczny dostęp do elementów</title>
+    <simpara>example1.php:</simpara>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+class classname
+{
+    function __construct()
+    {
+        echo __METHOD__,"\n";
+    }
+}
+function funcname()
+{
+    echo __FUNCTION__,"\n";
+}
+const constname = "global";
+
+$a = 'classname';
+$obj = new $a; // wyświetli classname::__construct
+$b = 'funcname';
+$b(); // prints funcname
+echo constant('constname'), "\n"; // wyświetli global
+?>
+    ]]>
+    </programlisting>
+   </example>
+   Należy użyć w pełni kwalifikowanej nazwy (nazwa klasy z prefiksem przestrzeni nazw).
+   Zauważ, że ponieważ nie ma różnicy między kwalifikowaną i w pełni kwalifikowaną Nazwą
+   wewnątrz dynamicznej nazwy klasy, nazwy funkcji lub nazwy stałej, wiodący odwrotny
+   ukośnik nie jest konieczny.
+   <example>
+    <title>Dynamiczny dostęp do elementów z przestrzenią nazw</title>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+namespace namespacename;
+class classname
+{
+    function __construct()
+    {
+        echo __METHOD__,"\n";
+    }
+}
+function funcname()
+{
+    echo __FUNCTION__,"\n";
+}
+const constname = "namespaced";
+
+/* należy pamiętać, że w przypadku użycia podwójnych cudzysłowów, "\\namespacename\\classname" must be used */
+$a = '\namespacename\classname';
+$obj = new $a; // wyświetli namespacename\classname::__construct
+$a = 'namespacename\classname';
+$obj = new $a; // również wyświetli namespacename\classname::__construct
+$b = 'namespacename\funcname';
+$b(); // wyświetli namespacename\funcname
+$b = '\namespacename\funcname';
+$b(); // również wyświetli namespacename\funcname
+echo constant('\namespacename\constname'), "\n"; // wyświetli namespaced
+echo constant('namespacename\constname'), "\n"; // również wyświetli namespaced
+?>
+    ]]>
+    </programlisting>
+   </example>
+  </para>
+  <para>
+   Koniecznie przeczytaj <link linkend="language.namespaces.faq.quote">uwagę o
+   uciekaniu nazw przestrzeni nazw w ciągach znaków</link>.
+  </para>
+ </sect1>
+ <sect1 xml:id="language.namespaces.nsconstants">
+  <title>Słowo kluczowe namespace i stała magiczna __NAMESPACE__</title>
+  <titleabbrev>Słowo kluczowe namespace i stała magiczna __NAMESPACE__</titleabbrev>
+  <?phpdoc print-version-for="namespaces"?>
+  <para>
+   PHP obsługuje dwa sposoby abstrakcyjnego dostępu do elementów w bieżącej przestrzeni nazw,
+   magiczną stałą <constant>__NAMESPACE__</constant> i słowo kluczowe <literal>namespace</literal>
+   keyword.
+  </para>
+  <para>
+   Wartość <constant>__NAMESPACE__</constant> jest ciągiem znaków, który zawiera bieżącą
+   namespace name. nazwę przestrzeni nazw. W globalnym kodzie bez przestrzeni nazw zawiera
+   on pusty ciąg znaków.
+   <example>
+    <title>Przykłąd __NAMESPACE__, kod z przestrzenią nazw</title>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+namespace MyProject;
+
+echo '"', __NAMESPACE__, '"'; // wyświetli "MyProject"
+?>
+]]>
+    </programlisting>
+   </example>
+   <example>
+    <title>Przykład __NAMESPACE__, kod globalny</title>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+
+echo '"', __NAMESPACE__, '"'; // wyświetli ""
+?>
+]]>
+    </programlisting>
+   </example>
+   Stała <constant>__NAMESPACE__</constant> constant jest przydatna na przykład do dynamicznego
+   konstruowania nazw:
+   <example>
+    <title>użycie __NAMESPACE__ do dynamicznego tworzenia nazw</title>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+namespace MyProject;
+
+function get($classname)
+{
+    $a = __NAMESPACE__ . '\\' . $classname;
+    return new $a;
+}
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+  <para>
+   Słowo kluczowe <literal>namespace</literal> może być użyte do jawnego żądania
+   elementu z bieżącej przestrzeni nazw lub podprzestrzeni. Jest to odpowiednik
+   przestrzeni nazw operatora <literal>self</literal> dla klas.
+   <example>
+    <title>operator namespace wewnątrz przestrzeni nazw</title>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+namespace MyProject;
+
+use blah\blah as mine; // zobacz "Korzystanie z przestrzeni nazw: Aliasowanie/Importowanie"
+
+blah\mine(); // wywołuje funkcje MyProject\blah\mine()
+namespace\blah\mine(); // wywołuje funkcje MyProject\blah\mine()
+
+namespace\func(); // wywołuje funkcje MyProject\func()
+namespace\sub\func(); // wywołuje funkcje MyProject\sub\func()
+namespace\cname::method(); // wywołuje statyczną metodę "method" klasy of class MyProject\cname
+$a = new namespace\sub\cname(); // tworzy instancję obiektu klasy MyProject\sub\cname
+$b = namespace\CONSTANT; // assigns value of constant MyProject\CONSTANT do $b
+?>
+]]>
+    </programlisting>
+   </example>
+   <example>
+    <title>operator namespace w kodzie globalnym</title>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+
+namespace\func(); // wywołuje funkcje func()
+namespace\sub\func(); // wywołuje funkcje sub\func()
+namespace\cname::method(); // wywołuje statyczną metodę "method" klasy cname
+$a = new namespace\sub\cname(); // tworzy instancję obiektu klasy sub\cname
+$b = namespace\CONSTANT; // przypisuje wartość stałej CONSTANT do $b
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </sect1>
+
+ <sect1 xml:id="language.namespaces.importing">
+  <title>Korzystanie z przestrzeni nazw: Aliasowanie/Importowanie</title>
+  <titleabbrev>Aliasowanie i Importowanie</titleabbrev>
+  <?phpdoc print-version-for="namespaces"?>
+  <para>
+   Możliwość odwoływania się do zewnętrznej w pełni kwalifikowanej nazwy za pomocą aliasu lub importowania
+   jest ważną cechą przestrzeni nazw. Jest to podobne do
+   zdolności uniksowych systemów plików do tworzenia dowiązań symbolicznych do pliku lub katalogu.
+  </para>
+  <para>
+   PHP może aliasować (/importować) stałe, funkcje, klasy, interfejsy, traity, enumy i przestrzenie nazw.
+  </para>
+  <para>
+   Aliasing jest wykonywany za pomocą operatora <literal>use</literal>.
+   Oto przykład pokazujący wszystkie 5 rodzajów importowania:
+   <example>
+    <title>importowanie/aliasowanie za pomocą operatora use</title>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+namespace foo;
+use My\Full\Classname as Another;
+
+// To jest to samo, co użycie My\Full\NSname as NSname
+use My\Full\NSname;
+
+// importowanie klasy globalnej
+use ArrayObject;
+
+// importowanie funkcji
+use function My\Full\functionName;
+
+// aliasowanie funkcji
+use function My\Full\functionName as func;
+
+// importowanie stałej
+use const My\Full\CONSTANT;
+
+$obj = new namespace\Another; // tworzy instancję obiektu klasy foo\Another
+$obj = new Another; // tworzy instancję obiektu klasy My\Full\Classname
+NSname\subns\func(); // wywołuje funkcję My\Full\NSname\subns\func 
+$a = new ArrayObject(array(1)); // tworzy instancję obiektu klasy ArrayObject
+// bez "use ArrayObject" utworzylibyśmy instancję obiektu klasy foo\ArrayObject
+func(); // wywołuje funkcję My\Full\functionName
+echo CONSTANT; // wyświetli wartość My\Full\CONSTANT
+?>
+]]>
+    </programlisting>
+   </example>
+   Należy zauważyć, że w przypadku nazw z przestrzenią nazw (w pełni kwalifikowane nazwy
+   przestrzeni nazw zawierające separator przestrzeni nazw, takie jak <literal>Foo\Bar</literal>
+   w przeciwieństwie do nazw globalnych, które tego nie robią, takich jak <literal>FooBar</literal>),
+   wiodący odwrotny ukośnik jest niepotrzebny i nie jest zalecany, ponieważ nazwy importu muszą być
+   w pełni kwalifikowane i nie są przetwarzane względem bieżącej przestrzeni nazw.
+  </para>
+  <para>
+   PHP dodatkowo obsługuje wygodny skrót do umieszczania wielu instrukcji
+   use w tej samej linii
+   <example>
+    <title>importowanie/aliasing z operatorem use, wiele instrukcji use połączonych</title>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+use My\Full\Classname as Another, My\Full\NSname;
+
+$obj = new Another; // tworzy instancję obiektu klasy My\Full\Classname
+NSname\subns\func(); // wywołuje funkcję My\Full\NSname\subns\func
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+  <para>
+   Importowanie jest wykonywane w czasie kompilacji, a więc nie ma wpływu na
+   dynamiczne nazwy klas, funkcji lub stałych.
+   <example>
+    <title>Importowanie i nazwy dynamiczne</title>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+use My\Full\Classname as Another, My\Full\NSname;
+
+$obj = new Another; // tworzy instancję obiektu klasy My\Full\Classname
+$a = 'Another';
+$obj = new $a;      // tworzy instancję obiektu klasy Another
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+  <para>
+   Ponadto importowanie wpływa tylko na nazwy niewykwalifikowane i kwalifikowane. W pełni
+   kwalifikowane nazwy są bezwzględne i import nie ma na nie wpływu.
+   <example>
+    <title>Importowanie i w pełni kwalifikowane nazwy</title>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+use My\Full\Classname as Another, My\Full\NSname;
+
+$obj = new Another; // tworzy instancję obiektu klasy My\Full\Classname
+$obj = new \Another; // tworzy instancję obiektu klasy Another
+$obj = new Another\thing; // tworzy instancję obiektu klasy My\Full\Classname\thing
+$obj = new \Another\thing; // tworzy instancję obiektu klasy Another\thing
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+  <sect2 xml:id="language.namespaces.importing.scope">
+   <title>Zasady dotyczące zakresu importowania</title>
+   <para>
+    Słowo kluczowe <literal>use</literal> musi być zadeklarowane w najbardziej
+    zewnętrznym zakresie pliku (zakres globalny) lub wewnątrz deklaracji
+    przestrzeni nazw. Dzieje się tak, ponieważ importowanie odbywa się w czasie
+    kompilacji, a nie w czasie wykonywania, więc nie można go ograniczyć do zakresu bloku.
+    Poniższy przykład pokazuje nielegalne użycie słowa kluczowego
+    <literal>use</literal>:
+   </para>
+   <para>
+    <example>
+     <title>Nielegalne zasady importowania</title>
+     <programlisting role="php">
+<![CDATA[
+<?php
+namespace Languages;
+
+function toGreenlandic()
+{
+    use Languages\Danish;
+
+    // ...
+}
+?>
+]]>
+     </programlisting>
+    </example>
+   </para>
+   <note>
+    <para>
+     Reguły importowania są oparte na plikach, co oznacza, że dołączone pliki
+     <emphasis>NIE</emphasis> odziedziczą reguły importowania pliku nadrzędnego.
+    </para>
+   </note>
+  </sect2>
+  <sect2 xml:id="language.namespaces.importing.group">
+   <title>Grupowe deklaracje <literal>use</literal></title>
+   <para>
+    Klasy, funkcje i stałe importowane z tej samej
+    &namespace; mogą być zgrupowane w jednej instrukcji
+    &use.namespace;.
+   </para>
+   <informalexample>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+use some\namespace\ClassA;
+use some\namespace\ClassB;
+use some\namespace\ClassC as C;
+
+use function some\namespace\fn_a;
+use function some\namespace\fn_b;
+use function some\namespace\fn_c;
+
+use const some\namespace\ConstA;
+use const some\namespace\ConstB;
+use const some\namespace\ConstC;
+
+// jest równoważna następującej zgrupowanej deklaracji use
+use some\namespace\{ClassA, ClassB, ClassC as C};
+use function some\namespace\{fn_a, fn_b, fn_c};
+use const some\namespace\{ConstA, ConstB, ConstC};
+]]>
+    </programlisting>
+   </informalexample>
+  </sect2>
+ </sect1>
+ <sect1 xml:id="language.namespaces.global">
+  <title>Global space</title>
+  <titleabbrev>Global space</titleabbrev>
+  <?phpdoc print-version-for="namespaces"?>
+  <para>
+   Bez definicji przestrzeni nazw, wszystkie definicje klas i funkcji są
+   umieszczane w przestrzeni globalnej - tak jak to było w PHP przed obsługą
+   przestrzeni nazw. Przedrostek nazwy <literal>\</literal> określi, że
+   nazwa jest wymagana z przestrzeni globalnej nawet w kontekście przestrzeni
+   nazw.
+   <example>
+    <title>Używanie specyfikacji przestrzeni globalnej</title>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+namespace A\B\C;
+
+/* Ta funkcja to A\B\C\fopen */
+function fopen() {
+     /* ... */
+     $f = \fopen(...); // wywołuje globalną fopen
+     return $f;
+}
+?>
+    ]]>
+    </programlisting>
+   </example>
+  </para>
+ </sect1>
+ <sect1 xml:id="language.namespaces.fallback">
+  <title>Korzystanie z przestrzeni nazw: powrót do przestrzeni globalnej dla funkcji i stałych</title>
+  <titleabbrev>Powrót do przestrzeni globalnej</titleabbrev>
+  <?phpdoc print-version-for="namespaces"?>
+  <para>
+   Wewnątrz przestrzeni nazw, gdy PHP napotka niewykwalifikowaną nazwę w kontekście nazwy klasy,
+   funkcji lub stałej, rozwiązuje je z różnymi priorytetami. Nazwy klas zawsze rozwiązywane są do
+   bieżącej nazwy przestrzeni nazw. Tak więc, aby uzyskać dostęp do wewnętrznych lub nieobjętych
+   przestrzenią nazw klas użytkownika, należy odwołać się do nich za pomocą ich w pełni kwalifikowanej nazwy, tak jak w:
+   <example>
+    <title>Dostęp do klas globalnych wewnątrz przestrzeni nazw</title>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+namespace A\B\C;
+class Exception extends \Exception {}
+
+$a = new Exception('hi'); // $a jest obiektem klasy A\B\C\Exception
+$b = new \Exception('hi'); // $b jest obiektem klasy Exception
+
+$c = new ArrayObject; // błąd krytyczny, klasa A\B\C\ArrayObject nie została znaleziona
+?>
+    ]]>
+    </programlisting>
+   </example>
+  </para>
+  <para>
+   W przypadku funkcji i stałych, PHP powróci do funkcji lub stałych
+   globalnych, jeśli taka funkcja lub stała nie istnieje.
+   <example>
+    <title>globalny powrót funkcji/stałych w przestrzeni nazw</title>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+namespace A\B\C;
+
+const E_ERROR = 45;
+function strlen($str)
+{
+    return \strlen($str) - 1;
+}
+
+echo E_ERROR, "\n"; // wyświetli "45"
+echo INI_ALL, "\n"; // wyświetli "7" - powraca do globalnego INI_ALL
+
+echo strlen('hi'), "\n"; // wyświetli "1"
+if (is_array('hi')) { // wyświetli "is not array"
+    echo "is array\n";
+} else {
+    echo "is not array\n";
+}
+?>
+    ]]>
+    </programlisting>
+   </example>
+  </para>
+ </sect1>
+
+ <sect1 xml:id="language.namespaces.rules">
+  <title>Zasady rozstrzygania nazw</title>
+  <titleabbrev>Zasady rozstrzygania nazw</titleabbrev>
+  <?phpdoc print-version-for="namespaces"?>
+  <para>
+   Dla celów niniejszych zasad dotyczących rozstrzygania, oto kilka ważnych definicji:
+   <variablelist>
+    <title>Definicje nazw przestrzeni nazw</title>
+    <varlistentry>
+     <term>Nazwa niekwalifikowana</term>
+     <listitem>
+      <para>
+       Jest to identyfikator bez separatora przestrzeni nazw taki jak <literal>Foo</literal>
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>Nazwa kwalifikowana</term>
+     <listitem>
+      <para>
+       Jest to identyfikator z separatorem przestrzeni nazw, taki jak <literal>Foo\Bar</literal>
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>W pełni kwalifikowana nazwa</term>
+     <listitem>
+      <para>
+       Jest to identyfikator z separatorem przestrzeni nazw, który zaczyna się od separatora
+       przestrzeni nazw, na przykład <literal>\Foo\Bar</literal>. Przestrzeń nazw
+       <literal>\Foo</literal> jest również w pełni kwalifikowaną nazwą.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>Nazwa względna</term>
+     <listitem>
+      <para>
+       Jest to identyfikator zaczynający się od <literal>namespace</literal>, taki jak
+       <literal>namespace\Foo\Bar</literal>.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+  <para>
+   Nazwy są rozwiązywane zgodnie z tymi zasadami rozstrzygania:
+   <orderedlist>
+    <listitem>
+     <simpara>
+      W pełni kwalifikowane nazwy zawsze rozwiązują się do nazwy bez wiodącego separatora przestrzeni nazw.
+      Na przykład <literal>\A\B</literal> rozwiązuje do <literal>A\B</literal>.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      Nazwy względne zawsze rozwiązują się do nazwy z <literal>namespace</literal> zastąpionym przez
+      bieżącą przestrzeń nazw. Jeśli nazwa występuje w globalnej przestrzeni nazw, prefiks
+      <literal>namespace\</literal> jest usuwany. Na przykład <literal>namespace\A</literal>
+      wewnątrz przestrzeni nazw <literal>X\Y</literal> rozwiązuje do <literal>X\Y\A</literal>. Ta sama nazwa
+      wewnątrz globalnej przestrzeni nazw jest rozwiązywana jako <literal>A</literal>.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      W przypadku nazw kwalifikowanych pierwszy segment nazwy jest tłumaczony zgodnie z bieżącą
+      tabelą importu klas/przestrzeni nazw. Na przykład, jeśli przestrzeń nazw <literal>A\B\C</literal> jest
+      importowana jako <literal>C</literal>, nazwa <literal>C\D\E</literal> jest tłumaczona na
+      <literal>A\B\C\D\E</literal>.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      W przypadku nazw kwalifikowanych, jeśli nie ma zastosowania żadna reguła importu, bieżąca przestrzeń nazw
+      jest dodawana do nazwy. Na przykład, nazwa <literal>C\D\E</literal> wewnątrz przestrzeni nazw <literal>A\B</literal>,
+      rozwiązuje do <literal>A\B\C\D\E</literal>.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      W przypadku nazw niewykwalifikowanych nazwa jest tłumaczona zgodnie z bieżącą tabelą importu
+      dla odpowiedniego typu symbolu. Oznacza to, że nazwy podobne do klas są tłumaczone zgodnie z
+      tabelą importu klas/przestrzeni nazw, nazwy funkcji zgodnie z tabelą importu funkcji, a stałe
+      zgodnie z tabelą importu stałych. Na przykład, po
+      <literal>use A\B\C;</literal> użycie takie jak <literal>new C()</literal> rozwiązuje się do nazwy
+      <literal>A\B\C()</literal>. Podobnie, po <literal>use function A\B\foo;</literal> użycie
+      takie jak <literal>foo()</literal> rozwiązuje do nazwy <literal>A\B\foo</literal>.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      W przypadku nazw niewykwalifikowanych, jeśli nie ma zastosowania żadna reguła importu, a nazwa odnosi
+      się do symbolu podobnego do klasy, bieżąca przestrzeń nazw jest dodawana. Na przykład <literal>new C()</literal>
+      wewnątrz przestrzeni nazw <literal>A\B</literal> rozwiązuje do nazwy <literal>A\B\C</literal>.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      W przypadku niewykwalifikowanych nazw, jeśli nie ma zastosowania żadna reguła importu, a nazwa
+      odnosi się do funkcji lub stałej, a kod znajduje się poza globalną przestrzenią nazw, nazwa jest rozwiązywana
+      w czasie wykonywania. Zakładając, że kod znajduje się w przestrzeni nazw <literal>A\B</literal>, oto jak
+      rozwiązywane jest wywołanie funkcji <literal>foo()</literal>:
+     </simpara>
+      <orderedlist>
+       <listitem>
+        <simpara>
+         Wyszukuje funkcję z bieżącej przestrzeni nazw:
+         <literal>A\B\foo()</literal>.
+        </simpara>
+       </listitem>
+       <listitem>
+        <simpara>
+         Próbuje znaleźć i wywołać funkcję <emphasis>globalną</emphasis>
+         <literal>foo()</literal>.
+        </simpara>
+       </listitem>
+      </orderedlist>
+    </listitem>
+   </orderedlist>
+  </para>
+  <example>
+   <title>Zilustrowane rozstrzygnięcia dotyczące nazw</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+namespace A;
+use B\D, C\E as F;
+
+// wywołania funkcji
+
+foo();      // najpierw próbuje wywołać funkcję "foo" zdefiniowaną w przestrzeni nazw "A"
+            // następnie wywołuje funkcję globalną "foo"
+
+\foo();     // wywołuje funkcję "foo" zdefiniowaną w zakresie globalnym
+
+my\foo();   // wywołuje funkcję "foo" zdefiniowaną w przestrzeni nazw "A\my"
+
+F();        // najpierw próbuje wywołać funkcję "F" zdefiniowaną w przestrzeni nazw "A"
+            // następnie wywołuje funkcję globalną "F"
+
+// referencje do klas
+
+new B();    // tworzy obiekt klasy "B" zdefiniowany w przestrzeni nazw "A"
+            // jeśli nie zostanie znaleziony, próbuje automatycznie załadować klasę "A\B"
+
+new D();    // używając reguł importu, tworzy obiekt klasy "D" zdefiniowany w przestrzeni nazw "B"
+            // jeśli nie zostanie znaleziona, próbuje automatycznie załadować klasę "B\D"
+
+new F();    // używając reguł importu, tworzy obiekt klasy "E" zdefiniowany w przestrzeni nazw "C"
+            // jeśli nie zostanie znaleziony, próbuje automatycznie załadować klasę "C\E"
+
+new \B();   // tworzy obiekt klasy "B" zdefiniowany w zakresie globalnym
+            // jeśli nie zostanie znaleziony, próbuje automatycznie załadować klasę "B"
+
+new \D();   // tworzy obiekt klasy "D" zdefiniowany w zakresie globalnym
+            // jeśli nie zostanie znaleziony, próbuje automatycznie załadować klasę "D"
+
+new \F();   // tworzy obiekt klasy "F" zdefiniowany w zakresie globalnym
+            // jeśli nie zostanie znaleziony, próbuje automatycznie załadować klasę "F"
+
+// statyczne metody/funkcje przestrzeni nazw z innej przestrzeni nazw
+
+B\foo();    // wywołuje funkcję "foo" z przestrzeni nazw "A\B"
+
+B::foo();   // wywołuje metodę "foo" klasy "B" zdefiniowanej w przestrzeni nazw "A"
+            // jeśli klasa "A\B" nie zostanie znaleziona, próbuje automatycznie załadować klasę "A\B"
+
+D::foo();   // używając reguł importu, wywołuje metodę "foo" klasy "D" zdefiniowanej w przestrzeni nazw "B"
+            // jeśli klasa "B\D" nie zostanie znaleziona, próbuje automatycznie załadować klasę "B\D"
+
+\B\foo();   // wywołuje funkcję "foo" z przestrzeni nazw "B"
+
+\B::foo();  // wywołuje metodę "foo" klasy "B" z zakresu globalnego
+            // jeśli klasa "B" nie zostanie znaleziona, próbuje automatycznie załadować klasę "B"
+
+// statyczne metody/funkcje bieżącej przestrzeni nazw
+
+A\B::foo();   // wywołuje metodę "foo" klasy "B" z przestrzeni nazw "A\A"
+              // jeśli klasa "A\A\B" nie zostanie znaleziona, próbuje automatycznie załadować klasę "A\A\B"
+
+\A\B::foo();  // wywołuje metodę "foo" klasy "B" z przestrzeni nazw "A"
+              // jeśli klasa "A\B" nie zostanie znaleziona, próbuje automatycznie załadować klasę "A\B"
+?>
+]]>
+   </programlisting>
+  </example>
+ </sect1>
+ <sect1 xml:id="language.namespaces.faq">
+  <title>FAQ: rzeczy, które musisz wiedzieć o przestrzeniach nazw</title>
+  <titleabbrev>FAQ</titleabbrev>
+  <?phpdoc print-version-for="namespaces"?>
+  <para>
+   Ten FAQ jest podzielony na dwie sekcje: najczęściej zadawane pytania i niektóre szczegóły
+   implementacji, które są pomocne w pełnym zrozumieniu.
+  </para>
+  <para>
+   Po pierwsze, najczęstsze pytania.
+   <orderedlist>
+    <listitem>
+     <simpara>
+      <link linkend="language.namespaces.faq.shouldicare">Jeśli nie używam przestrzeni nazw, czy
+      powinienem się tym przejmować?</link>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <link linkend="language.namespaces.faq.globalclass">Jak używać klas wewnętrznych lub globalnych
+      przestrzeni nazw?</link>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <link linkend="language.namespaces.faq.innamespace">Jak używać klas przestrzeni
+      azw, funkcji lub stałych w ich własnych przestrzeniach nazw?</link>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <link linkend="language.namespaces.faq.full">
+       Jak rozwiązywana jest nazwa taka jak <literal>\my\name</literal> lub
+       <literal>\name</literal>?
+      </link>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <link linkend="language.namespaces.faq.qualified">W jaki sposób rozwiązywana jest
+      nazwa taka jak <literal>my\name</literal>?</link>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <link linkend="language.namespaces.faq.shortname1">W jaki sposób rozwiązywana jest
+      niewykwalifikowana nazwa klasy, taka jak <literal>name</literal>?</link>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <link linkend="language.namespaces.faq.shortname2">Jak rozwiązywana jest niewykwalifikowana
+      nazwa funkcji lub niewykwalifikowana nazwa stałej, taka jak
+      <literal>name</literal>?</link>
+     </simpara>
+    </listitem>
+   </orderedlist>
+  </para>
+  <para>
+   Istnieje kilka szczegółów implementacji przestrzeni nazw,
+   które są pomocne do zrozumienia.
+   <orderedlist>
+    <listitem>
+     <simpara>
+      <link linkend="language.namespaces.faq.conflict">Nazwy importu nie mogą kolidować z
+      klasami zdefiniowanymi w tym samym pliku.</link>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <link linkend="language.namespaces.faq.nested">Zagnieżdżone przestrzenie nazw nie są dozwolone.
+      </link>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <link linkend="language.namespaces.faq.quote">Dynamiczne nazwy przestrzeni nazw
+      (cytowane identyfikatory) powinny unikać odwrotnego ukośnika.</link>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <link linkend="language.namespaces.faq.constants">Niezdefiniowane stałe, do których
+      odwołuje się dowolny odwrotny ukośnik, giną z błędem krytycznym</link>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <link linkend="language.namespaces.faq.builtinconst">Nie można nadpisać stałych
+      specjalnych &null;, &true; or &false;</link>
+     </simpara>
+    </listitem>
+   </orderedlist>
+  </para>
+  <sect2 xml:id="language.namespaces.faq.shouldicare">
+   <title>Jeśli nie używam przestrzeni nazw, czy powinienem się tym przejmować?</title>
+   <para>
+    nie. Przestrzenie nazw nie wpływają w żaden sposób na istniejący kod ani na kod, 
+    który ma zostać napisany, a który nie zawiera przestrzeni nazw. Możesz
+    napisać taki kod, jeśli chcesz:
+   </para>
+   <para>
+    <example>
+     <title>Dostęp do klas globalnych poza przestrzenią nazw</title>
+     <programlisting role="php">
+<![CDATA[
+<?php
+$a = new \stdClass;
+?>
+]]>
+     </programlisting>
+    </example>
+   </para>
+   <para>
+    Jest to funkcjonalnie równoważne:
+   </para>
+   <para>
+    <example>
+     <title>Dostęp do klas globalnych poza przestrzenią nazw</title>
+     <programlisting role="php">
+<![CDATA[
+<?php
+$a = new stdClass;
+?>
+]]>
+     </programlisting>
+    </example>
+   </para>
+  </sect2>
+  <sect2 xml:id="language.namespaces.faq.globalclass">
+   <title>Jak używać klas wewnętrznych lub globalnych w przestrzeni nazw?</title>
+   <para>
+    <example>
+     <title>Dostęp do klas wewnętrznych w przestrzeniach nazw</title>
+     <programlisting role="php">
+<![CDATA[
+<?php
+namespace foo;
+$a = new \stdClass;
+
+function test(\ArrayObject $parameter_type_example = null) {}
+
+$a = \DirectoryIterator::CURRENT_AS_FILEINFO;
+
+// rozszerzenie klasy wewnętrznej lub globalnej
+class MyException extends \Exception {}
+?>
+]]>
+     </programlisting>
+    </example>
+   </para>
+  </sect2>
+  <sect2 xml:id="language.namespaces.faq.innamespace">
+   <title>
+    Jak używać klas, funkcji lub stałych przestrzeni nazw w ich własnych
+    przestrzeniach nazw?
+   </title>
+   <para>
+    <example>
+     <title>Dostęp do wewnętrznych klas, funkcji lub stałych w przestrzeniach nazw</title>
+     <programlisting role="php">
+<![CDATA[
+<?php
+namespace foo;
+
+class MyClass {}
+
+// używając klasy z bieżącej przestrzeni nazw jako typu parametru
+function test(MyClass $parameter_type_example = null) {}
+// inny sposób użycia klasy z bieżącej przestrzeni nazw jako typu parametru
+function test(\foo\MyClass $parameter_type_example = null) {}
+
+// rozszerzenie klasy z bieżącej przestrzeni nazw
+class Extended extends MyClass {}
+
+// dostęp do funkcji globalnej
+$a = \globalfunc();
+
+// dostęp do stałej globalnej
+$b = \INI_ALL;
+?>
+]]>
+     </programlisting>
+    </example>
+   </para>
+  </sect2>
+  <sect2 xml:id="language.namespaces.faq.full">
+   <title>
+     Jak rozwiązywana jest nazwa taka jak <literal>\my\name</literal> lub
+     <literal>\name</literal>?
+   </title>
+   <para>
+    Nazwy rozpoczynające się od <literal>\</literal> zawsze rozwiązują się tak,
+    jak wyglądają, więc <literal>\my\name</literal> to w rzeczywistości <literal>my\name</literal>,
+    i <literal>\Exception</literal> to <literal>Exception</literal>.
+    <example>
+     <title>W pełni kwalifikowane nazwy</title>
+     <programlisting role="php">
+<![CDATA[
+<?php
+namespace foo;
+$a = new \my\name(); // tworzy instancję klasy "my\name"
+echo \strlen('hi'); // wywołuje funkcję "strlen"
+$a = \INI_ALL; // $a jest ustawione na wartość stałej "INI_ALL"
+?>
+]]>
+     </programlisting>
+    </example>
+   </para>
+  </sect2>
+  <sect2 xml:id="language.namespaces.faq.qualified">
+   <title>Jak rozwiązywana jest nazwa taka jak <literal>my\name</literal>?</title>
+   <para>
+    Nazwy zawierające odwrotny ukośnik, ale nie zaczynające się od odwrotnego ukośnika, 
+    takie jak <literal>my\name</literal> mogą być rozwiązywane na 2 różne sposoby.
+   </para>
+   <para>
+    Jeśli istnieje
+    instrukcja importu, która aliasuje inną nazwę do <literal>my</literal>, to
+    alias importu jest stosowany do <literal>my</literal> w <literal>my\name</literal>.
+   </para>
+   <para>
+    W przeciwnym razie bieżąca nazwa przestrzeni nazw jest dodawana do <literal>my\name</literal>.
+   </para>
+   <para>
+    <example>
+     <title>Kwalifikowane nazwy</title>
+     <programlisting role="php">
+<![CDATA[
+<?php
+namespace foo;
+use blah\blah as foo;
+
+$a = new my\name(); // tworzy instancję klasy "foo\my\name"
+foo\bar::name(); // wywołuje statyczną metodę "name" w klasie "blah\blah\bar"
+my\bar(); // wywołuje funkcję "foo\my\bar"
+$a = my\BAR; // ustawia $a na wartość stałej "foo\my\BAR".
+?>
+]]>
+     </programlisting>
+    </example>
+   </para>
+  </sect2>
+  <sect2 xml:id="language.namespaces.faq.shortname1">
+   <title>Jak rozwiązywana jest niewykwalifikowana nazwa klasy, taka jak <literal>name</literal>?</title>
+   <para>
+    Nazwy klas, które nie zawierają odwrotnego ukośnika jak
+    <literal>name</literal> mogą być rozwiązywane na 2 różne sposoby.
+   </para>
+   <para>
+    Jeśli istnieje
+    instrukcja importu, która aliasuje inną nazwę do <literal>name</literal>, wówczas
+    alias importu jest stosowany.
+   </para>
+   <para>
+    W przeciwnym razie bieżąca nazwa przestrzeni nazw jest dodawana do <literal>name</literal>.
+   </para>
+   <para>
+    <example>
+     <title>Niekwalifikowane nazwy klas</title>
+     <programlisting role="php">
+<![CDATA[
+<?php
+namespace foo;
+use blah\blah as foo;
+
+$a = new name(); // tworzy instancję klasy "foo\name"
+foo::name(); // wywołuje statyczną metodę "name" w klasie "blah\blah"
+?>
+]]>
+     </programlisting>
+    </example>
+   </para>
+  </sect2>
+  <sect2 xml:id="language.namespaces.faq.shortname2">
+   <title>
+    Jak rozwiązywana jest niekwalifikowana nazwa funkcji lub niekwalifikowana nazwa stałej,
+    taka jak <literal>name</literal>?
+   </title>
+   <para>
+    Nazwy funkcji lub stałych, które nie zawierają odwrotnego ukośnika jak
+    <literal>name</literal> mogą być rozwiązywane na 2 różne sposoby.
+   </para>
+   <para>
+    Po pierwsze, bieżąca nazwa przestrzeni nazw jest dodawana do <literal>name</literal>.
+   </para>
+   <para>
+    Wreszcie, jeśli stała lub funkcja <literal>name</literal> nie istnieje
+    w bieżącej przestrzeni nazw, używana jest globalna stała lub funkcja <literal>name</literal>,
+    jeśli istnieje.
+   </para>
+   <para>
+    <example>
+     <title>Niekwalifikowane nazwy funkcji lub stałych</title>
+     <programlisting role="php">
+<![CDATA[
+<?php
+namespace foo;
+use blah\blah as foo;
+
+const FOO = 1;
+
+function my() {}
+function foo() {}
+function sort(&$a)
+{
+    \sort($a); // wywołuje globalną funkcję "sort"
+    $a = array_flip($a);
+    return $a;
+}
+
+my(); // wywołuje "foo\my"
+$a = strlen('hi'); // wywołuje globalną funkcję "strlen", ponieważ "foo\strlen" nie istnieje
+$arr = array(1,3,2);
+$b = sort($arr); // wywołuję funkcję "foo\sort"
+$c = foo(); // wywołuje funkcję "foo\foo" - import nie jest stosowany
+
+$a = FOO; // ustawia $a na wartość stałej "foo\FOO" - import nie jest stosowany
+$b = INI_ALL; // ustawia $b na wartość globalnej stałej "INI_ALL"
+?>
+]]>
+     </programlisting>
+    </example>
+   </para>
+  </sect2>
+  <sect2 xml:id="language.namespaces.faq.conflict">
+   <title>Nazwy importu nie mogą kolidować z klasami zdefiniowanymi w tym samym pliku.</title>
+   <para>
+    Następujące kombinacje skryptów są legalne:
+    <informalexample>
+     <simpara>file1.php</simpara>
+     <programlisting role="php">
+     <![CDATA[
+<?php
+namespace my\stuff;
+class MyClass {}
+?>
+     ]]>
+     </programlisting>
+     <simpara>another.php</simpara>
+     <programlisting role="php">
+     <![CDATA[
+<?php
+namespace another;
+class thing {}
+?>
+     ]]>
+     </programlisting>
+     <simpara>file2.php</simpara>
+     <programlisting role="php">
+     <![CDATA[
+<?php
+namespace my\stuff;
+include 'file1.php';
+include 'another.php';
+
+use another\thing as MyClass;
+$a = new MyClass; // tworzy instancję klasy "thing" z przestrzeni nazw another
+?>
+     ]]>
+     </programlisting>
+    </informalexample>
+   </para>
+   <para>
+    Nie ma konfliktu nazw, mimo że klasa <literal>MyClass</literal> istnieje w
+    przestrzeni nazw <literal>my\stuff</literal> ponieważ definicja MyClass znajduje
+    się w osobnym pliku. Jednak następny przykład powoduje błąd krytyczny dotyczący
+    konfliktu nazw, ponieważ klasa MyClass jest zdefiniowana w tym samym pliku co instrukcja use.
+    <informalexample>
+     <programlisting role="php">
+     <![CDATA[
+<?php
+namespace my\stuff;
+use another\thing as MyClass;
+class MyClass {} // błąd krytyczny: MyClass koliduje z instrukcją import
+$a = new MyClass;
+?>
+     ]]>
+     </programlisting>
+    </informalexample>
+   </para>
+  </sect2>
+  <sect2 xml:id="language.namespaces.faq.nested">
+   <title>Zagnieżdżone przestrzenie nazw nie są dozwolone.</title>
+   <para>
+    PHP nie pozwala na zagnieżdżanie przestrzeni nazw
+    <informalexample>
+     <programlisting role="php">
+     <![CDATA[
+<?php
+namespace my\stuff {
+    namespace nested {
+        class foo {}
+    }
+}
+?>
+     ]]>
+     </programlisting>
+    </informalexample>
+    Łatwo jest jednak symulować zagnieżdżone przestrzenie nazw w ten sposób:
+    <informalexample>
+     <programlisting role="php">
+     <![CDATA[
+<?php
+namespace my\stuff\nested {
+    class foo {}
+}
+?>
+     ]]>
+     </programlisting>
+    </informalexample>
+   </para>
+  </sect2>
+
+  <sect2 xml:id="language.namespaces.faq.quote">
+   <title>Dynamiczne nazwy przestrzeni nazw (cytowane identyfikatory) powinny unikać odwrotnego ukośnika</title>
+   <para>
+    Bardzo ważne jest, aby zdać sobie sprawę, że ponieważ odwrotny ukośnik jest używany jako znak ucieczki
+    w łańcuchach, zawsze powinien być podwojony, gdy jest używany wewnątrz łańcucha. W przeciwnym
+    razie istnieje ryzyko niezamierzonych konsekwencji:
+    <example>
+     <title>Niebezpieczeństwa związane z używaniem nazw wewnątrz podwójnie cytowanego ciągu znaków</title>
+     <programlisting role="php">
+      <![CDATA[
+<?php
+$a = "dangerous\name"; // \n jest nową linią wewnątrz podwójnie cytowanych ciągów znakowych!
+$obj = new $a;
+
+$a = 'not\at\all\dangerous'; // tutaj nie ma problemów.
+$obj = new $a;
+?>
+      ]]>
+     </programlisting>
+    </example>
+    Wewnątrz ciągów zanków w pojedynczych cudzysłowach, sekwencja ucieczki
+    odwrotnego ukośnika jest znacznie bezpieczniejsza w użyciu, ale nadal
+    zaleca się ucieczkę odwrotnego ukośnika we wszystkich ciągach znaków jako najlepszą praktykę.
+   </para>
+  </sect2>
+  <sect2 xml:id="language.namespaces.faq.constants">
+   <title>Niezdefiniowane stałe, do których odwołuje się dowolny odwrotny ukośnik, giną z błędem krytycznym</title>
+   <para>
+    Każda niezdefiniowana stała, która nie jest kwalifikowana, jak <literal>FOO</literal> spowoduje
+    wyświetlenie powiadomienia wyjaśniającego, że PHP przyjęło <literal>FOO</literal> was the value
+    jako wartość stałej. Każda stała, kwalifikowana lub w pełni kwalifikowana, która zawiera
+    odwrotny ukośnik, spowoduje błąd krytyczny, jeśli nie zostanie znaleziona.
+    <example>
+     <title>Niezdefiniowane stałe</title>
+     <programlisting role="php">
+      <![CDATA[
+<?php
+namespace bar;
+$a = FOO; // produkuje powiadomienie - niezdefiniowana stała "FOO" przyjęto "FOO";
+$a = \FOO; // błąd krytyczny, niezdefiniowana stała przestrzeni nazw FOO
+$a = Bar\FOO; // błąd krytyczny, niezdefiniowana stała przestrzeni nazw bar\Bar\FOO
+$a = \Bar\FOO; // błąd krytyczny, niezdefiniowana stała przestrzeni nazw bar\FOO
+?>
+      ]]>
+     </programlisting>
+    </example>
+   </para>
+  </sect2>
+  <sect2 xml:id="language.namespaces.faq.builtinconst">
+   <title>Nie można nadpisać stałych specjalnych &null;, &true; or &false;</title>
+   <para>
+    Każda próba zdefiniowania stałej w przestrzeni nazw, która jest specjalną, wbudowaną
+    stałą, skutkuje błędem krytycznym
+    <example>
+     <title>Undefined constants</title>
+     <programlisting role="php">
+      <![CDATA[
+<?php
+namespace bar;
+const NULL = 0; // błąd krytyczny;
+const true = 'stupid'; // również błąd krytyczny;
+// etc.
+?>
+      ]]>
+     </programlisting>
+    </example>
+   </para>
+  </sect2>
+ </sect1>
+</chapter>
+
+<!-- Keep this comment at the end of the file
+ Local variables:
+ mode: sgml
+ sgml-omittag:t
+ sgml-shorttag:t
+ sgml-minimize-attributes:nil
+ sgml-always-quote-attributes:t
+ sgml-indent-step:1
+ sgml-indent-data:t
+ indent-tabs-mode:nil
+ sgml-parent-document:nil
+ sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+ sgml-exposed-tags:nil
+ sgml-local-catalogs:nil
+ sgml-local-ecat-files:nil
+ End:
+ vim600: syn=xml fen fdm=syntax fdl=2 si
+ vim: et tw=78 syn=sgml
+ vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Z tymi słowami miałem problem:

1. W enumarations.xml:
- "case, cases" - ostatecznie zostawiłem angielską nazwą, ale może być jako: przypadek lub prostu instrukcja case. Pominąłem liczbę mnogą, czyli nie pisałem cases.
- "backed", "Backed Enum", "Pure Enum" - zostawiłem angielskie nazwy

2. W generators.xml:
- "yield" - przetłumaczyłem jako "zwróci"

3. W namespaces.xml:
- "resolve" - przetłumaczyłem jako "rozwiązuje", ale może powinno być np. rozpoznaje lub rozstrzyga
- "illegal" - przetłumaczyłem jako "nielegalny", ale może powino być "niedozwolony"
- "fallback" - przetłumaczyłem jako "powróci, powrót"

Z góry dziękuję za review!