### PR TITLE
Add translations for OOP5 files

### DIFF
--- a/language/oop5/late-static-bindings.xml
+++ b/language/oop5/late-static-bindings.xml
@@ -1,0 +1,292 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 009f215fc983eeded6161676bcffdd8cf3b6b080 Maintainer: sobak Status: ready -->
+ <sect1 xml:id="language.oop5.late-static-bindings" xmlns="http://docbook.org/ns/docbook">
+  <title>Późne wiązanie statyczne</title>
+  <para>
+   PHP implementuje funkcjonalność zwaną późnym wiązaniem statycznym, która
+   może być używana do odwoływania się do wywoływanej klasy w kontekście
+   dziedziczenia statycznego.
+  </para>
+
+  <para>
+   Dokładniej rzecz ujmując, późne wiązanie statyczne działa poprzez
+   przechowywanie klasy wymienionej w ostatnim "nieprzekazującym wywołaniu".
+   W przypadku wywołań metod statycznych jest to klasa jawnie nazwana
+   (zwykle ta po lewej stronie operatora
+   <link linkend="language.oop5.paamayim-nekudotayim"><literal>::</literal></link>);
+   w przypadku wywołań metod niestatycznych jest to klasa obiektu. "Wywołanie
+   przekazujące" to wywołanie statyczne wprowadzone przez <literal>self::</literal>,
+   <literal>parent::</literal>, <literal>static::</literal>, lub, jeśli
+   poruszamy się w górę hierarchii klas, <function>forward_static_call</function>.
+   <!-- technically, static:: may be non forwarding, but it's irrelevant -->
+
+   Funkcja <function>get_called_class</function> może być użyta do pobrania
+   łańcucha znaków z nazwą wywoływanej klasy, a <literal>static::</literal>
+   wprowadza jej zasięg.
+  </para>
+
+  <para>
+   Funkcjonalność ta została nazwana "późnym wiązaniem statycznym" z myślą
+   o wewnętrznym działaniu. "Późne wiązanie" wynika z faktu, że
+   <literal>static::</literal> nie będzie rozwiązywane przy użyciu klasy,
+   w której metoda została zdefiniowana, lecz będzie obliczane na podstawie
+   informacji dostępnych w czasie wykonywania.
+
+   Zostało to również nazwane "wiązaniem statycznym", ponieważ może być
+   używane (choć nie tylko) do wywołań metod statycznych.
+  </para>
+
+  <sect2 xml:id="language.oop5.late-static-bindings.self">
+   <title>Ograniczenia <literal>self::</literal></title>
+   <para>
+    Statyczne odwołania do bieżącej klasy, takie jak <literal>self::</literal>
+    lub <literal>__CLASS__</literal>, są rozwiązywane przy użyciu klasy,
+    do której funkcja należy, czyli klasy, w której została zdefiniowana:
+   </para>
+   <example>
+    <title>Użycie <literal>self::</literal></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+class A
+{
+    public static function who()
+    {
+        echo __CLASS__;
+    }
+
+    public static function test()
+    {
+        self::who();
+    }
+}
+
+class B extends A
+{
+    public static function who()
+    {
+        echo __CLASS__;
+    }
+}
+
+B::test();
+
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+A
+]]>
+    </screen>
+   </example>
+
+  </sect2>
+
+  <sect2 xml:id="language.oop5.late-static-bindings.usage">
+   <title>Użycie późnego wiązania statycznego</title>
+
+   <para>
+    Późne wiązanie statyczne próbuje rozwiązać to ograniczenie, wprowadzając
+    słowo kluczowe, które odwołuje się do klasy, która została pierwotnie
+    wywołana w czasie wykonywania. W zasadzie słowo kluczowe, które pozwoliłoby
+    odwoływać się do <literal>B</literal> z <literal>test()</literal>
+    w poprzednim przykładzie. Zdecydowano, aby nie wprowadzać nowego słowa
+    kluczowego, lecz zamiast tego użyć <literal>static</literal>, które
+    było już zarezerwowane.
+   </para>
+
+   <example>
+    <title>Proste użycie <literal>static::</literal></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+class A
+{
+    public static function who()
+    {
+        echo __CLASS__;
+    }
+
+    public static function test()
+    {
+        static::who(); // Tutaj działa późne wiązanie statyczne
+    }
+}
+
+class B extends A
+{
+    public static function who()
+    {
+        echo __CLASS__;
+    }
+}
+
+B::test();
+
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+B
+]]>
+    </screen>
+   </example>
+   <note>
+    <para>
+     W kontekstach niestatycznych wywoływaną klasą będzie klasa instancji
+     obiektu. Ponieważ <literal>$this-></literal> będzie próbowało wywołać
+     prywatne metody z tego samego zasięgu, użycie <literal>static::</literal>
+     może dać inne wyniki. Kolejną różnicą jest to, że <literal>static::</literal>
+     może odwoływać się jedynie do właściwości statycznych.
+    </para>
+   </note>
+   <example>
+    <title>Użycie <literal>static::</literal> w kontekście niestatycznym</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+class A
+{
+    private function foo()
+    {
+        echo "Success!\n";
+    }
+
+    public function test()
+    {
+        $this->foo();
+        static::foo();
+    }
+}
+
+class B extends A
+{
+    /* foo() zostanie skopiowane do B, więc jego zasięg nadal będzie A
+    * i wywołanie zakończy się powodzeniem */
+}
+
+class C extends A
+{
+    private function foo()
+    {
+        /* Oryginalna metoda jest zastąpiona; zasięgiem nowej jest C */
+    }
+}
+
+$b = new B();
+$b->test();
+
+$c = new C();
+try {
+    $c->test();
+} catch (Error $e) {
+    echo $e->getMessage();
+}
+
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Success!
+Success!
+Success!
+Call to private method C::foo() from scope A
+]]>
+    </screen>
+   </example>
+   <note>
+    <para>
+     Rozwiązywanie późnego wiązania statycznego zatrzymuje się na w pełni
+     rozwiązanym wywołaniu statycznym, bez mechanizmu awaryjnego. Z drugiej
+     strony, wywołania statyczne używające słów kluczowych takich jak
+     <literal>parent::</literal> lub <literal>self::</literal> przekazują
+     informację o wywołaniu dalej.
+    </para>
+    <example>
+     <title>Wywołania przekazujące i nieprzekazujące</title>
+     <programlisting role="php">
+<![CDATA[
+<?php
+
+class A
+{
+    public static function foo()
+    {
+        static::who();
+    }
+
+    public static function who()
+    {
+        echo __CLASS__ . "\n";
+    }
+}
+
+class B extends A
+{
+    public static function test()
+    {
+        A::foo();
+        parent::foo();
+        self::foo();
+    }
+
+    public static function who()
+    {
+        echo __CLASS__ . "\n";
+    }
+}
+
+class C extends B
+{
+    public static function who()
+    {
+        echo __CLASS__ . "\n";
+    }
+}
+
+C::test();
+
+?>
+]]>
+     </programlisting>
+     &example.outputs;
+     <screen>
+<![CDATA[
+A
+C
+C
+]]>
+     </screen>
+    </example>
+   </note>
+  </sect2>
+ </sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/language/oop5/overloading.xml
+++ b/language/oop5/overloading.xml
@@ -1,0 +1,334 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: d6f54016d62904cfd8200604aadd5e3f0d9bad97 Maintainer: sobak Status: ready -->
+ <sect1 xml:id="language.oop5.overloading" xmlns="http://docbook.org/ns/docbook">
+  <title>Przeciążanie</title>
+
+  <para>
+   Przeciążanie w PHP zapewnia środki do dynamicznego
+   <quote>tworzenia</quote> właściwości i metod.
+   Te dynamiczne encje są przetwarzane za pomocą metod magicznych,
+   które można zdefiniować w klasie dla różnych typów akcji.
+  </para>
+
+  <para>
+   Metody przeciążające są wywoływane podczas interakcji
+   z właściwościami lub metodami, które nie zostały zadeklarowane lub nie są
+   <link linkend="language.oop5.visibility">widoczne</link> w bieżącym
+   zasięgu. W dalszej części tej sekcji będą używane terminy
+   <quote>niedostępne właściwości</quote> i <quote>niedostępne
+   metody</quote> w odniesieniu do tej kombinacji deklaracji
+   i widoczności.
+  </para>
+
+  <para>
+   Wszystkie metody przeciążające muszą być zdefiniowane jako <literal>public</literal>.
+  </para>
+
+  <note>
+   <para>
+    Żaden z argumentów tych metod magicznych nie może być
+    <link linkend="functions.arguments.by-reference">przekazywany
+    przez referencję</link>.
+   </para>
+  </note>
+
+  <note>
+   <para>
+    Interpretacja <quote>przeciążania</quote> w PHP jest inna niż
+    w większości języków obiektowych. Przeciążanie tradycyjnie
+    zapewnia możliwość posiadania wielu metod o tej samej nazwie,
+    ale z różną liczbą i typami argumentów.
+   </para>
+  </note>
+
+  <sect2 xml:id="language.oop5.overloading.members">
+   <title>Przeciążanie właściwości</title>
+
+   <methodsynopsis xml:id="object.set">
+    <modifier>public</modifier> <type>void</type><methodname>__set</methodname>
+    <methodparam><type>string</type><parameter>name</parameter></methodparam>
+    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+   </methodsynopsis>
+   <methodsynopsis xml:id="object.get">
+    <modifier>public</modifier> <type>mixed</type><methodname>__get</methodname>
+    <methodparam><type>string</type><parameter>name</parameter></methodparam>
+   </methodsynopsis>
+   <methodsynopsis xml:id="object.isset">
+    <modifier>public</modifier> <type>bool</type><methodname>__isset</methodname>
+    <methodparam><type>string</type><parameter>name</parameter></methodparam>
+   </methodsynopsis>
+   <methodsynopsis xml:id="object.unset">
+    <modifier>public</modifier> <type>void</type><methodname>__unset</methodname>
+    <methodparam><type>string</type><parameter>name</parameter></methodparam>
+   </methodsynopsis>
+
+   <para>
+    <link linkend="object.set">__set()</link> jest uruchamiane przy zapisywaniu
+    danych do niedostępnych (chronionych lub prywatnych) lub nieistniejących
+    właściwości.
+   </para>
+
+   <para>
+    <link linkend="object.get">__get()</link> jest wykorzystywane do odczytywania
+    danych z niedostępnych (chronionych lub prywatnych) lub nieistniejących
+    właściwości.
+   </para>
+
+   <para>
+    <link linkend="object.isset">__isset()</link> jest wywoływane przez
+    <function>isset</function> lub <function>empty</function>
+    na niedostępnych (chronionych lub prywatnych) lub nieistniejących
+    właściwościach.
+   </para>
+
+   <para>
+    <link linkend="object.unset">__unset()</link> jest wywoływane, gdy
+    <function>unset</function> jest używane na niedostępnych (chronionych
+    lub prywatnych) lub nieistniejących właściwościach.
+   </para>
+
+   <para>
+    Argument <varname>$name</varname> jest nazwą właściwości, z którą
+    zachodzi interakcja. Argument <varname>$value</varname> metody
+    <link linkend="object.set">__set()</link> określa wartość, na jaką
+    właściwość <varname>$name</varname> powinna zostać ustawiona.
+   </para>
+
+   <para>
+    Przeciążanie właściwości działa jedynie w kontekście obiektowym. Te metody
+    magiczne nie będą wywoływane w kontekście statycznym. Dlatego
+    metody te nie powinny być deklarowane jako
+    <link linkend="language.oop5.static">static</link>.
+    Ostrzeżenie jest generowane, jeśli jedna z magicznych metod
+    przeciążających jest zadeklarowana jako <literal>static</literal>.
+   </para>
+
+   <note>
+    <para>
+     Wartość zwracana przez <link linkend="object.set">__set()</link> jest
+     ignorowana ze względu na sposób, w jaki PHP przetwarza operator
+     przypisania. Podobnie, <link linkend="object.get">__get()</link> nigdy
+     nie jest wywoływane przy łączeniu przypisań w taki sposób:
+     <literal><![CDATA[ $a = $obj->b = 8; ]]></literal>
+    </para>
+   </note>
+
+   <note>
+    <para>
+     PHP nie wywoła przeciążonej metody z wnętrza tej samej przeciążonej metody.
+     Oznacza to na przykład, że napisanie <code>return $this->foo</code> wewnątrz
+     <link linkend="object.get">__get()</link> zwróci <literal>null</literal>
+     i wygeneruje <constant>E_WARNING</constant>, jeśli nie ma zdefiniowanej
+     właściwości <literal>foo</literal>, zamiast wywoływać
+     <link linkend="object.get">__get()</link> po raz drugi.
+     Jednakże metody przeciążające mogą niejawnie wywoływać inne metody
+     przeciążające (na przykład
+     <link linkend="object.set">__set()</link> wywołujące <link linkend="object.get">__get()</link>).
+    </para>
+   </note>
+
+   <example>
+    <title>
+     Przeciążanie właściwości za pomocą metod <link linkend="object.get">__get()</link>,
+     <link linkend="object.set">__set()</link>, <link linkend="object.isset">__isset()</link>
+     i <link linkend="object.unset">__unset()</link>
+    </title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+class PropertyTest
+{
+    /**  Miejsce na przeciążone dane.  */
+    private $data = array();
+
+    /**  Przeciążanie nie jest używane na zadeklarowanych właściwościach.  */
+    public $declared = 1;
+
+    /**  Przeciążanie jest używane tylko przy dostępie spoza klasy.  */
+    private $hidden = 2;
+
+    public function __set($name, $value)
+    {
+        echo "Ustawianie '$name' na '$value'\n";
+        $this->data[$name] = $value;
+    }
+
+    public function __get($name)
+    {
+        echo "Pobieranie '$name'\n";
+        if (array_key_exists($name, $this->data)) {
+            return $this->data[$name];
+        }
+
+        $trace = debug_backtrace();
+        trigger_error(
+            'Niezdefiniowana właściwość przez __get(): ' . $name .
+            ' w ' . $trace[0]['file'] .
+            ' w linii ' . $trace[0]['line'],
+            E_USER_NOTICE);
+        return null;
+    }
+
+    public function __isset($name)
+    {
+        echo "Czy '$name' jest ustawione?\n";
+        return isset($this->data[$name]);
+    }
+
+    public function __unset($name)
+    {
+        echo "Usuwanie '$name'\n";
+        unset($this->data[$name]);
+    }
+
+    /**  To nie jest metoda magiczna, jest tu tylko jako przykład.  */
+    public function getHidden()
+    {
+        return $this->hidden;
+    }
+}
+
+
+$obj = new PropertyTest;
+
+$obj->a = 1;
+echo $obj->a . "\n\n";
+
+var_dump(isset($obj->a));
+unset($obj->a);
+var_dump(isset($obj->a));
+echo "\n";
+
+echo $obj->declared . "\n\n";
+
+echo "Poeksperymentujmy z prywatną właściwością 'hidden':\n";
+echo "Prywatne są widoczne wewnątrz klasy, więc __get() nie jest używane...\n";
+echo $obj->getHidden() . "\n";
+echo "Prywatne nie są widoczne spoza klasy, więc __get() jest używane...\n";
+echo $obj->hidden . "\n";
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen role="php">
+<![CDATA[
+Ustawianie 'a' na '1'
+Pobieranie 'a'
+1
+
+Czy 'a' jest ustawione?
+bool(true)
+Usuwanie 'a'
+Czy 'a' jest ustawione?
+bool(false)
+
+1
+
+Poeksperymentujmy z prywatną właściwością 'hidden':
+Prywatne są widoczne wewnątrz klasy, więc __get() nie jest używane...
+2
+Prywatne nie są widoczne spoza klasy, więc __get() jest używane...
+Pobieranie 'hidden'
+
+
+Notice:  Niezdefiniowana właściwość przez __get(): hidden w <file> w linii 70 w <file> w linii 29
+]]>
+    </screen>
+
+   </example>
+  </sect2>
+
+  <sect2 xml:id="language.oop5.overloading.methods">
+   <title>Przeciążanie metod</title>
+
+   <methodsynopsis xml:id="object.call">
+    <modifier>public</modifier> <type>mixed</type><methodname>__call</methodname>
+    <methodparam><type>string</type><parameter>name</parameter></methodparam>
+    <methodparam><type>array</type><parameter>arguments</parameter></methodparam>
+   </methodsynopsis>
+   <methodsynopsis xml:id="object.callstatic">
+    <modifier>public static</modifier> <type>mixed</type><methodname>__callStatic</methodname>
+    <methodparam><type>string</type><parameter>name</parameter></methodparam>
+    <methodparam><type>array</type><parameter>arguments</parameter></methodparam>
+   </methodsynopsis>
+
+   <para>
+    <link linkend="object.call">__call()</link> jest wywoływane przy próbie
+    wywołania niedostępnych metod w kontekście obiektowym.
+   </para>
+
+   <para>
+    <link linkend="object.callstatic">__callStatic()</link> jest wywoływane
+    przy próbie wywołania niedostępnych metod w kontekście statycznym.
+   </para>
+
+   <para>
+    Argument <varname>$name</varname> jest nazwą wywoływanej metody.
+    Argument <varname>$arguments</varname> jest tablicą numerowaną
+    zawierającą parametry przekazane do metody <varname>$name</varname>.
+   </para>
+
+   <example>
+    <title>
+     Przeciążanie metod za pomocą <link linkend="object.call">__call()</link>
+     i <link linkend="object.callstatic">__callStatic()</link>
+    </title>
+    <programlisting role="php">
+  <![CDATA[
+<?php
+class MethodTest
+{
+    public function __call($name, $arguments)
+    {
+        // Uwaga: wartość $name rozróżnia wielkość liter.
+        echo "Wywołanie metody obiektu '$name' "
+             . implode(', ', $arguments). "\n";
+    }
+
+    public static function __callStatic($name, $arguments)
+    {
+        // Uwaga: wartość $name rozróżnia wielkość liter.
+        echo "Wywołanie metody statycznej '$name' "
+             . implode(', ', $arguments). "\n";
+    }
+}
+
+$obj = new MethodTest;
+$obj->runTest('w kontekście obiektu');
+
+MethodTest::runTest('w kontekście statycznym');
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen role="php">
+<![CDATA[
+Wywołanie metody obiektu 'runTest' w kontekście obiektu
+Wywołanie metody statycznej 'runTest' w kontekście statycznym
+]]>
+    </screen>
+   </example>
+
+  </sect2>
+
+ </sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/language/oop5/traits.xml
+++ b/language/oop5/traits.xml
@@ -1,0 +1,709 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c1f37a6c270aadbbb3da56a3973ffd62197adf2b Maintainer: sobak Status: ready -->
+ <sect1 xml:id="language.oop5.traits" xmlns="http://docbook.org/ns/docbook">
+  <title>Traity</title>
+  <para>
+   PHP implementuje sposób na ponowne wykorzystanie kodu, zwany traitami.
+  </para>
+  <para>
+   Traity są mechanizmem ponownego wykorzystania kodu w językach z pojedynczym
+   dziedziczeniem, takich jak PHP. Trait ma na celu zmniejszenie pewnych ograniczeń
+   pojedynczego dziedziczenia, umożliwiając programiście swobodne ponowne
+   wykorzystanie zestawów metod w kilku niezależnych klasach, które mogą istnieć
+   w różnych hierarchiach klas. Semantyka kombinacji traitów i klas jest
+   zdefiniowana w sposób, który zmniejsza złożoność i pozwala uniknąć typowych
+   problemów związanych z wielokrotnym dziedziczeniem i domieszkami (Mixin).
+  </para>
+  <para>
+   Trait jest podobny do klasy, ale służy jedynie do grupowania funkcjonalności
+   w szczegółowy i spójny sposób. Nie jest możliwe utworzenie instancji traita
+   samego w sobie. Jest on dodatkiem do tradycyjnego dziedziczenia i umożliwia
+   poziomą kompozycję zachowań; to znaczy zastosowanie składowych klasy bez
+   konieczności dziedziczenia.
+  </para>
+  <example xml:id="language.oop5.traits.basicexample">
+    <title>Przykład użycia traita</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+trait TraitA {
+    public function sayHello() {
+        echo 'Hello';
+    }
+}
+
+trait TraitB {
+    public function sayWorld() {
+        echo 'World';
+    }
+}
+
+class MyHelloWorld
+{
+    use TraitA, TraitB; // Klasa może używać wielu traitów
+
+    public function sayHelloWorld() {
+        $this->sayHello();
+        echo ' ';
+        $this->sayWorld();
+        echo "!\n";
+    }
+}
+
+$myHelloWorld = new MyHelloWorld();
+$myHelloWorld->sayHelloWorld();
+
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Hello World!
+]]>
+    </screen>
+   </example>
+
+  <sect2 xml:id="language.oop5.traits.precedence">
+   <title>Kolejność pierwszeństwa</title>
+   <para>
+    Odziedziczona składowa z klasy bazowej jest nadpisywana przez składową
+    wstawioną przez trait. Kolejność pierwszeństwa jest taka, że składowe
+    z bieżącej klasy nadpisują metody traita, które z kolei nadpisują
+    odziedziczone metody.
+   </para>
+   <example xml:id="language.oop5.traits.precedence.examples.ex1">
+    <title>Przykład kolejności pierwszeństwa</title>
+    <para>
+     Odziedziczona metoda z klasy bazowej jest nadpisywana przez metodę
+     wstawioną do MyHelloWorld z traita SayWorld. Zachowanie jest takie samo
+     dla metod zdefiniowanych w klasie MyHelloWorld. Kolejność pierwszeństwa
+     jest taka, że metody z bieżącej klasy nadpisują metody traita, które
+     z kolei nadpisują metody z klasy bazowej.
+    </para>
+    <programlisting role="php">
+<![CDATA[
+<?php
+class Base {
+    public function sayHello() {
+        echo 'Hello ';
+    }
+}
+
+trait SayWorld {
+    public function sayHello() {
+        parent::sayHello();
+        echo 'World!';
+    }
+}
+
+class MyHelloWorld extends Base {
+    use SayWorld;
+}
+
+$o = new MyHelloWorld();
+$o->sayHello();
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Hello World!
+]]>
+    </screen>
+   </example>
+   <example xml:id="language.oop5.traits.precedence.examples.ex2">
+    <title>Alternatywny przykład kolejności pierwszeństwa</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+trait HelloWorld {
+    public function sayHello() {
+        echo 'Hello World!';
+    }
+}
+
+class TheWorldIsNotEnough {
+    use HelloWorld;
+    public function sayHello() {
+        echo 'Hello Universe!';
+    }
+}
+
+$o = new TheWorldIsNotEnough();
+$o->sayHello();
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Hello Universe!
+]]>
+    </screen>
+   </example>
+  </sect2>
+
+  <sect2 xml:id="language.oop5.traits.multiple">
+   <title>Użycie wielu traitów</title>
+   <para>
+    Wiele traitów może być dodanych do klasy poprzez wymienienie ich w instrukcji
+    <literal>use</literal>, oddzielonych przecinkami.
+   </para>
+   <example xml:id="language.oop5.traits.multiple.ex1">
+    <title>Użycie wielu traitów</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+trait Hello {
+    public function sayHello() {
+        echo 'Hello ';
+    }
+}
+
+trait World {
+    public function sayWorld() {
+        echo 'World';
+    }
+}
+
+class MyHelloWorld {
+    use Hello, World;
+    public function sayExclamationMark() {
+        echo '!';
+    }
+}
+
+$o = new MyHelloWorld();
+$o->sayHello();
+$o->sayWorld();
+$o->sayExclamationMark();
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Hello World!
+]]>
+    </screen>
+   </example>
+  </sect2>
+
+  <sect2 xml:id="language.oop5.traits.conflict">
+   <title>Rozwiązywanie konfliktów</title>
+   <para>
+    Jeśli dwa traity wstawiają metodę o tej samej nazwie, generowany jest błąd
+    krytyczny, jeśli konflikt nie zostanie jawnie rozwiązany.
+   </para>
+   <para>
+    Aby rozwiązać konflikty nazw między traitami używanymi w tej samej klasie,
+    należy użyć operatora <literal>insteadof</literal>, aby wybrać dokładnie
+    jedną z kolidujących metod.
+   </para>
+   <para>
+    Ponieważ pozwala to jedynie na wykluczenie metod, operator <literal>as</literal>
+    może być użyty, aby dodać alias do jednej z metod. Operator
+    <literal>as</literal> nie zmienia nazwy metody i nie wpływa na żadną
+    inną metodę.
+   </para>
+   <example xml:id="language.oop5.traits.conflict.ex1">
+    <title>Rozwiązywanie konfliktów</title>
+    <para>
+      W tym przykładzie Talker używa traitów A i B.
+      Ponieważ A i B mają kolidujące metody, definiuje użycie
+      wariantu smallTalk z traita B i wariantu bigTalk z traita A.
+    </para>
+    <para>
+      Aliased_Talker wykorzystuje operator <literal>as</literal>,
+      aby móc użyć implementacji bigTalk z B pod dodatkowym aliasem
+      <literal>talk</literal>.
+    </para>
+    <programlisting role="php" annotations="non-interactive">
+<![CDATA[
+<?php
+trait A {
+    public function smallTalk() {
+        echo 'a';
+    }
+    public function bigTalk() {
+        echo 'A';
+    }
+}
+
+trait B {
+    public function smallTalk() {
+        echo 'b';
+    }
+    public function bigTalk() {
+        echo 'B';
+    }
+}
+
+class Talker {
+    use A, B {
+        B::smallTalk insteadof A;
+        A::bigTalk insteadof B;
+    }
+}
+
+class Aliased_Talker {
+    use A, B {
+        B::smallTalk insteadof A;
+        A::bigTalk insteadof B;
+        B::bigTalk as talk;
+    }
+}
+?>
+]]>
+    </programlisting>
+   </example>
+  </sect2>
+
+  <sect2 xml:id="language.oop5.traits.visibility">
+   <title>Zmiana widoczności metod</title>
+   <para>
+    Za pomocą składni <literal>as</literal> można również dostosować widoczność
+    metody w klasie korzystającej z traita.
+   </para>
+   <example xml:id="language.oop5.traits.visibility.ex1">
+    <title>Zmiana widoczności metod</title>
+    <programlisting role="php" annotations="non-interactive">
+<![CDATA[
+<?php
+trait HelloWorld {
+    public function sayHello() {
+        echo 'Hello World!';
+    }
+}
+
+// Zmiana widoczności sayHello
+class MyClass1 {
+    use HelloWorld { sayHello as protected; }
+}
+
+// Alias metody ze zmienioną widocznością
+// widoczność sayHello nie została zmieniona
+class MyClass2 {
+    use HelloWorld { sayHello as private myPrivateHello; }
+}
+?>
+]]>
+    </programlisting>
+   </example>
+  </sect2>
+
+  <sect2 xml:id="language.oop5.traits.composition">
+   <title>Traity złożone z traitów</title>
+   <para>
+    Tak jak klasy mogą korzystać z traitów, tak samo mogą to robić inne traity.
+    Używając jednego lub więcej traitów w definicji traita, może on być częściowo
+    lub całkowicie złożony ze składowych zdefiniowanych w tych innych traitach.
+   </para>
+   <example xml:id="language.oop5.traits.composition.ex1">
+    <title>Traity złożone z traitów</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+trait Hello {
+    public function sayHello() {
+        echo 'Hello ';
+    }
+}
+
+trait World {
+    public function sayWorld() {
+        echo 'World!';
+    }
+}
+
+trait HelloWorld {
+    use Hello, World;
+}
+
+class MyHelloWorld {
+    use HelloWorld;
+}
+
+$o = new MyHelloWorld();
+$o->sayHello();
+$o->sayWorld();
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Hello World!
+]]>
+    </screen>
+   </example>
+  </sect2>
+
+  <sect2 xml:id="language.oop5.traits.abstract">
+   <title>Abstrakcyjne składowe traitów</title>
+   <para>
+    Traity wspierają użycie metod abstrakcyjnych w celu nałożenia wymagań
+    na klasę korzystającą z traita. Obsługiwane są metody publiczne, chronione
+    i prywatne. Przed PHP 8.0.0 obsługiwane były jedynie publiczne i chronione
+    metody abstrakcyjne.
+   </para>
+   <caution>
+    <simpara>
+     Od PHP 8.0.0 sygnatura metody konkretnej musi być zgodna z
+     <link linkend="language.oop.lsp">zasadami kompatybilności sygnatur</link>.
+     Wcześniej sygnatura mogła się różnić.
+    </simpara>
+   </caution>
+   <example xml:id="language.oop5.traits.abstract.ex1">
+    <title>Wyrażanie wymagań za pomocą metod abstrakcyjnych</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+trait Hello {
+    public function sayHelloWorld() {
+        echo 'Hello'.$this->getWorld();
+    }
+    abstract public function getWorld();
+}
+
+class MyHelloWorld {
+    private $world;
+    use Hello;
+    public function getWorld() {
+        return $this->world;
+    }
+    public function setWorld($val) {
+        $this->world = $val;
+    }
+}
+?>
+]]>
+    </programlisting>
+   </example>
+  </sect2>
+
+  <sect2 xml:id="language.oop5.traits.static">
+   <title>Statyczne składowe traitów</title>
+   <para>
+    Traity mogą definiować zmienne statyczne, metody statyczne i właściwości statyczne.
+   </para>
+   <note>
+    <para>
+     Od PHP 8.1.0 bezpośrednie wywoływanie metody statycznej lub dostęp do
+     właściwości statycznej traita jest przestarzałe.
+     Metody statyczne i właściwości powinny być dostępne jedynie poprzez klasę
+     korzystającą z traita.
+    </para>
+   </note>
+   <example xml:id="language.oop5.traits.static.ex1">
+    <title>Zmienne statyczne</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+trait Counter
+{
+    public function inc()
+    {
+        static $c = 0;
+        $c = $c + 1;
+        echo "$c\n";
+    }
+}
+
+class C1
+{
+    use Counter;
+}
+
+class C2
+{
+    use Counter;
+}
+
+$o = new C1();
+$o->inc();
+$p = new C2();
+$p->inc();
+
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+1
+1
+]]>
+    </screen>
+   </example>
+   <example xml:id="language.oop5.traits.static.ex2">
+    <title>Metody statyczne</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+trait StaticExample
+{
+    public static function doSomething()
+    {
+        return 'Doing something';
+    }
+}
+
+class Example
+{
+    use StaticExample;
+}
+
+echo Example::doSomething();
+
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Doing something
+]]>
+    </screen>
+   </example>
+   <example xml:id="language.oop5.traits.static.ex3">
+    <title>Właściwości statyczne</title>
+    <caution>
+     <simpara>
+      Przed PHP 8.3.0 właściwości statyczne zdefiniowane w traicie były
+      współdzielone między wszystkimi klasami w tej samej hierarchii
+      dziedziczenia, które korzystały z tego traita.
+      Od PHP 8.3.0, jeśli klasa potomna używa traita z właściwością statyczną,
+      będzie ona traktowana jako odrębna od tej zdefiniowanej w klasie nadrzędnej.
+     </simpara>
+    </caution>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+
+trait T
+{
+    public static $counter = 1;
+}
+
+class A
+{
+    use T;
+
+    public static function incrementCounter()
+    {
+        static::$counter++;
+    }
+}
+
+class B extends A
+{
+    use T;
+}
+
+A::incrementCounter();
+
+echo A::$counter, "\n";
+echo B::$counter, "\n";
+
+?>
+]]>
+    </programlisting>
+    &example.outputs.83;
+    <screen>
+<![CDATA[
+2
+1
+]]>
+    </screen>
+   </example>
+  </sect2>
+
+  <sect2 xml:id="language.oop5.traits.properties">
+   <title>Właściwości</title>
+   <para>
+    Traity mogą również definiować właściwości.
+   </para>
+   <example xml:id="language.oop5.traits.properties.example">
+    <title>Definiowanie właściwości</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+trait PropertiesTrait
+{
+    public $x = 1;
+}
+
+class PropertiesExample
+{
+    use PropertiesTrait;
+}
+
+$example = new PropertiesExample();
+$example->x;
+
+?>
+]]>
+    </programlisting>
+   </example>
+   <para>
+    Jeśli trait definiuje właściwość, klasa nie może definiować właściwości
+    o tej samej nazwie, chyba że jest ona kompatybilna (ta sama widoczność i typ,
+    modyfikator readonly oraz wartość początkowa), w przeciwnym razie generowany
+    jest błąd krytyczny.
+   </para>
+   <example xml:id="language.oop5.traits.properties.conflicts">
+    <title>Rozwiązywanie konfliktów</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+trait PropertiesTrait {
+    public $same = true;
+    public $different1 = false;
+    public bool $different2;
+    public bool $different3;
+}
+
+class PropertiesExample {
+    use PropertiesTrait;
+    public $same = true;
+    public $different1 = true; // Błąd krytyczny
+    public string $different2; // Błąd krytyczny
+    readonly protected bool $different3; // Błąd krytyczny
+}
+?>
+]]>
+    </programlisting>
+   </example>
+  </sect2>
+
+ <sect2 xml:id="language.oop5.traits.constants">
+  <title>&Constants;</title>
+  <para>
+   Traity mogą, od PHP 8.2.0, definiować również stałe.
+  </para>
+  <example xml:id="language.oop5.traits.constants.example">
+   <title>Definiowanie stałych</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+trait ConstantsTrait {
+    public const FLAG_MUTABLE = 1;
+    final public const FLAG_IMMUTABLE = 5;
+}
+
+class ConstantsExample {
+    use ConstantsTrait;
+}
+
+$example = new ConstantsExample;
+echo $example::FLAG_MUTABLE;
+?>
+]]>
+   </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+1
+]]>
+    </screen>
+  </example>
+  <para>
+   Jeśli trait definiuje stałą, klasa nie może definiować stałej o tej samej
+   nazwie, chyba że jest kompatybilna (ta sama widoczność, wartość początkowa
+   i finalność), w przeciwnym razie generowany jest błąd krytyczny.
+  </para>
+  <example xml:id="language.oop5.traits.constants.conflicts">
+   <title>Rozwiązywanie konfliktów</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+trait ConstantsTrait {
+    public const FLAG_MUTABLE = 1;
+    final public const FLAG_IMMUTABLE = 5;
+}
+
+class ConstantsExample {
+    use ConstantsTrait;
+    public const FLAG_IMMUTABLE = 5; // Błąd krytyczny
+}
+?>
+]]>
+   </programlisting>
+  </example>
+ </sect2>
+
+ <sect2 xml:id="language.oop5.traits.final-methods">
+  <title>Metody finalne</title>
+  <simpara>
+   Od PHP 8.3.0 modyfikator <link linkend="language.oop5.final">final</link>
+   może być zastosowany za pomocą operatora <literal>as</literal>
+   do metod importowanych z traitów. Może to być wykorzystane, aby zapobiec
+   nadpisywaniu metody przez klasy potomne. Jednakże klasa, która korzysta
+   z traita, nadal może nadpisać tę metodę.
+  </simpara>
+  <example xml:id="language.oop5.traits.final-methods.example">
+   <title>Definiowanie metody z traita jako <literal>final</literal></title>
+   <programlisting role="php">
+    <![CDATA[
+<?php
+
+trait CommonTrait
+{
+    public function method()
+    {
+        echo 'Hello';
+    }
+}
+
+class FinalExampleA
+{
+    use CommonTrait {
+        CommonTrait::method as final; // Słowo 'final' zapobiega nadpisywaniu metody przez klasy potomne
+    }
+}
+
+class FinalExampleB extends FinalExampleA
+{
+    public function method() {}
+}
+
+?>
+]]>
+   </programlisting>
+    &example.outputs.similar;
+    <screen>
+<![CDATA[
+Fatal error: Cannot override final method FinalExampleA::method() in ...
+]]>
+    </screen>
+  </example>
+ </sect2>
+
+ </sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/language/oop5/variance.xml
+++ b/language/oop5/variance.xml
@@ -1,0 +1,323 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 2e7c00fd314a708ecbd495ef7cc9ae8c8462c33c Maintainer: sobak Status: ready -->
+<sect1 xml:id="language.oop5.variance" xmlns="http://docbook.org/ns/docbook">
+ <title>Kowariancja i kontrawariancja</title>
+
+ <para>
+  W PHP 7.2.0 wprowadzono częściową kontrawariancję poprzez usunięcie
+  ograniczeń typów parametrów w metodzie klasy potomnej. Od PHP 7.4.0
+  dodano pełne wsparcie dla kowariancji i kontrawariancji.
+ </para>
+ <para>
+  Kowariancja pozwala metodzie klasy potomnej zwracać bardziej szczegółowy typ
+  niż typ zwracany przez metodę klasy nadrzędnej. Kontrawariancja pozwala
+  typowi parametru być mniej szczegółowym w metodzie klasy potomnej niż
+  w metodzie klasy nadrzędnej.
+ </para>
+ <para>
+  Deklaracja typu jest uważana za bardziej szczegółową w następującym przypadku:
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     Typ jest usuwany z
+     <link linkend="language.types.type-system.composite.union">typu unii</link>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     Typ jest dodawany do
+     <link linkend="language.types.type-system.composite.intersection">typu przecięcia</link>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     Typ klasy jest zmieniany na typ klasy potomnej
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <type>iterable</type> jest zmieniany na <type>array</type> lub <classname>Traversable</classname>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+
+  Klasa typu jest uważana za mniej szczegółową, jeśli jest odwrotnie.
+ </para>
+
+ <sect2 xml:id="language.oop5.variance.covariance">
+  <title>Kowariancja</title>
+
+  <para>
+   Aby zilustrować działanie kowariancji, tworzona jest prosta abstrakcyjna
+   klasa nadrzędna <varname>Animal</varname>. <varname>Animal</varname>
+   będzie rozszerzana przez klasy potomne
+   <varname>Cat</varname> i <varname>Dog</varname>.
+  </para>
+
+  <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+abstract class Animal
+{
+    protected string $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    abstract public function speak();
+}
+
+class Dog extends Animal
+{
+    public function speak()
+    {
+        echo $this->name . " barks";
+    }
+}
+
+class Cat extends Animal
+{
+    public function speak()
+    {
+        echo $this->name . " meows";
+    }
+}
+]]>
+   </programlisting>
+  </informalexample>
+
+  <para>
+   W tym przykładzie nie ma metod zwracających wartości. Zostanie dodanych
+   kilka fabryk, które zwrócą nowy obiekt typu <varname>Animal</varname>,
+   <varname>Cat</varname> lub <varname>Dog</varname>.
+  </para>
+
+  <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+interface AnimalShelter
+{
+    public function adopt(string $name): Animal;
+}
+
+class CatShelter implements AnimalShelter
+{
+    public function adopt(string $name): Cat // zamiast zwracać typ Animal, może zwrócić typ Cat
+    {
+        return new Cat($name);
+    }
+}
+
+class DogShelter implements AnimalShelter
+{
+    public function adopt(string $name): Dog // zamiast zwracać typ Animal, może zwrócić typ Dog
+    {
+        return new Dog($name);
+    }
+}
+
+$kitty = (new CatShelter)->adopt("Ricky");
+$kitty->speak();
+echo "\n";
+
+$doggy = (new DogShelter)->adopt("Mavrick");
+$doggy->speak();
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+Ricky meows
+Mavrick barks
+]]>
+   </screen>
+  </informalexample>
+ </sect2>
+
+ <sect2 xml:id="language.oop5.variance.contravariance">
+  <title>Kontrawariancja</title>
+
+  <para>
+   Kontynuując poprzedni przykład z klasami <varname>Animal</varname>,
+   <varname>Cat</varname> i <varname>Dog</varname>, dodane zostaną klasy
+   <varname>Food</varname> i <varname>AnimalFood</varname>, a do
+   abstrakcyjnej klasy <varname>Animal</varname> dodana zostanie metoda
+   <varname>eat(AnimalFood $food)</varname>.
+  </para>
+
+  <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+class Food {}
+
+class AnimalFood extends Food {}
+
+abstract class Animal
+{
+    protected string $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function eat(AnimalFood $food)
+    {
+        echo $this->name . " eats " . get_class($food);
+    }
+}
+]]>
+   </programlisting>
+  </informalexample>
+
+  <para>
+   Aby zobaczyć zachowanie kontrawariancji, metoda <varname>eat</varname>
+   jest nadpisana w klasie <varname>Dog</varname>, aby akceptować dowolny
+   obiekt typu <varname>Food</varname>. Klasa <varname>Cat</varname>
+   pozostaje bez zmian.
+  </para>
+
+  <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+class Dog extends Animal
+{
+    public function eat(Food $food) {
+        echo $this->name . " eats " . get_class($food);
+    }
+}
+]]>
+   </programlisting>
+  </informalexample>
+
+  <para>
+   Następny przykład pokaże zachowanie kontrawariancji.
+  </para>
+
+  <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$kitty = (new CatShelter)->adopt("Ricky");
+$catFood = new AnimalFood();
+$kitty->eat($catFood);
+echo "\n";
+
+$doggy = (new DogShelter)->adopt("Mavrick");
+$banana = new Food();
+$doggy->eat($banana);
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+Ricky eats AnimalFood
+Mavrick eats Food
+]]>
+   </screen>
+
+   <para>
+    Ale co się stanie, jeśli <varname>$kitty</varname> spróbuje
+    <methodname>eat</methodname> <varname>$banana</varname>?
+   </para>
+
+   <programlisting role="php">
+<![CDATA[
+$kitty->eat($banana);
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+Fatal error: Uncaught TypeError: Argument 1 passed to Animal::eat() must be an instance of AnimalFood, instance of Food given
+]]>
+   </screen>
+  </informalexample>
+ </sect2>
+ <sect2>
+  <title>Wariancja właściwości</title>
+  <simpara>
+   Domyślnie właściwości nie są ani kowariantne, ani kontrawariantne, są więc
+   inwariantne. To znaczy, że ich typ nie może się zmienić w klasie potomnej.
+   Powodem jest to, że operacje "get" muszą być kowariantne,
+   a operacje "set" muszą być kontrawariantne.
+   Jedynym sposobem, aby właściwość spełniała oba wymagania, jest bycie inwariantną.
+  </simpara>
+  <simpara>
+   Od PHP 8.4.0, wraz z dodaniem właściwości abstrakcyjnych (w interfejsie lub klasie abstrakcyjnej) i
+   <link linkend="language.oop5.property-hooks.virtual">właściwości wirtualnych</link>,
+   możliwe jest zadeklarowanie właściwości, która ma jedynie operację get lub set.
+   W rezultacie abstrakcyjne właściwości lub właściwości wirtualne, które wymagają jedynie operacji "get", mogą być kowariantne.
+   Podobnie abstrakcyjna właściwość lub właściwość wirtualna, która wymaga jedynie operacji "set", może być kontrawariantna.
+  </simpara>
+  <simpara>
+   Jednakże gdy właściwość ma zarówno operację get, jak i set,
+   nie jest już ani kowariantna, ani kontrawariantna w kontekście dalszego rozszerzania.
+   To znaczy, że jest teraz inwariantna.
+  </simpara>
+  <example>
+   <title>Wariancja typów właściwości</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+class Animal {}
+class Dog extends Animal {}
+class Poodle extends Dog {}
+
+interface PetOwner
+{
+    // Wymagana jest tylko operacja get, więc może być kowariantna.
+    public Animal $pet { get; }
+}
+
+class DogOwner implements PetOwner
+{
+    // Może to być bardziej restrykcyjny typ, ponieważ strona "get"
+    // nadal zwraca Animal. Jednakże jako natywna właściwość
+    // klasy potomne nie mogą już zmieniać tego typu.
+    public Dog $pet;
+}
+
+class PoodleOwner extends DogOwner
+{
+    // To NIE JEST DOZWOLONE, ponieważ DogOwner::$pet ma zdefiniowane
+    // i wymagane zarówno operacje get, jak i set.
+    public Poodle $pet;
+}
+?>
+]]>
+   </programlisting>
+  </example>
+ </sect2>
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Add Polish translations for 4 missing OOP5 files: traits, late-static-bindings, overloading, and variance.