### PR TITLE
Add translation for reference/fpm

### DIFF
--- a/reference/fpm/book.xml
+++ b/reference/fpm/book.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 0ba9e74ebc71fc8aa5fcd0f5f48654a4a6a83368 Maintainer: lacatoire Status: ready -->
+<!-- $Revision$ -->
+<book xmlns="http://docbook.org/ns/docbook" xml:id="book.fpm">
+ <?phpdoc extension-membership="core" ?>
+ <title>FastCGI Process Manager</title>
+
+ <preface xml:id="intro.fpm">
+  &reftitle.intro;
+  &fpm.intro;
+  <simpara>
+   Ten moduł SAPI jest dołączony do PHP.
+  </simpara>
+ </preface>
+
+ &reference.fpm.setup;
+ &reference.fpm.observability;
+ &reference.fpm.reference;
+
+</book>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/fpm/functions/fastcgi-finish-request.xml
+++ b/reference/fpm/functions/fastcgi-finish-request.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 0ba9e74ebc71fc8aa5fcd0f5f48654a4a6a83368 Maintainer: lacatoire Status: ready -->
+<!-- $Revision$ -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.fastcgi-finish-request">
+ <refnamediv>
+  <refname>fastcgi_finish_request</refname>
+  <refpurpose>Wysyła wszystkie dane odpowiedzi do klienta</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>fastcgi_finish_request</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Ta funkcja wysyła wszystkie dane odpowiedzi do klienta i kończy żądanie.
+   Pozwala to na wykonywanie czasochłonnych zadań bez utrzymywania otwartego
+   połączenia z klientem.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.success;
+  </simpara>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/fpm/functions/fpm-get-status.xml
+++ b/reference/fpm/functions/fpm-get-status.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 0ba9e74ebc71fc8aa5fcd0f5f48654a4a6a83368 Maintainer: lacatoire Status: ready -->
+<!-- $Revision$ -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.fpm-get-status">
+ <refnamediv>
+  <refname>fpm_get_status</refname>
+  <refpurpose>Zwraca bieżący status puli FPM</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>array</type><type>false</type></type><methodname>fpm_get_status</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Ta funkcja zwraca pełny bieżący status puli FPM jako tablicę asocjacyjną. Zawsze zwraca
+   pełny status, w tym informacje o statusie poszczególnych procesów. Więcej szczegółów
+   znajduje się w <link linkend="fpm.status">przewodniku po stronie statusu FPM</link>.
+  </simpara>
+  <simpara>
+   Należy pamiętać, że ta funkcja będzie zdefiniowana tylko wtedy, gdy FPM jest używany do
+   obsługi skryptu.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Tablica asocjacyjna zawierająca pełny status puli FPM,&return.falseforfailure;.
+  </simpara>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+ Local variables:
+ mode: sgml
+ sgml-omittag:t
+ sgml-shorttag:t
+ sgml-minimize-attributes:nil
+ sgml-always-quote-attributes:t
+ sgml-indent-step:1
+ sgml-indent-data:t
+ indent-tabs-mode:nil
+ sgml-parent-document:nil
+ sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+ sgml-exposed-tags:nil
+ sgml-local-catalogs:nil
+ sgml-local-ecat-files:nil
+ End:
+ vim600: syn=xml fen fdm=syntax fdl=2 si
+ vim: et tw=78 syn=sgml
+ vi: ts=1 sw=1
+ -->

--- a/reference/fpm/observability.xml
+++ b/reference/fpm/observability.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: fab4ea95f4fe1471be947602d0e9be32fb802265 Maintainer: lacatoire Status: ready -->
+<!-- $Revision$ -->
+
+<chapter xml:id="fpm.observability">
+ <title>Obserwowalność</title>
+
+ &reference.fpm.status;
+
+</chapter>
+
+ <!-- Keep this comment at the end of the file
+ Local variables:
+ mode: sgml
+ sgml-omittag:t
+ sgml-shorttag:t
+ sgml-minimize-attributes:nil
+ sgml-always-quote-attributes:t
+ sgml-indent-step:1
+ sgml-indent-data:t
+ indent-tabs-mode:nil
+ sgml-parent-document:nil
+ sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+ sgml-exposed-tags:nil
+ sgml-local-catalogs:nil
+ sgml-local-ecat-files:nil
+ End:
+ vim600: syn=xml fen fdm=syntax fdl=2 si
+ vim: et tw=78 syn=sgml
+ vi: ts=1 sw=1
+ -->

--- a/reference/fpm/reference.xml
+++ b/reference/fpm/reference.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: b2e83b46c6aa7f8278e80d3c0e8a049b7583f6cc Maintainer: lacatoire Status: ready -->
+<!-- $Revision$ -->
+
+<reference xml:id="ref.fpm" xmlns="http://docbook.org/ns/docbook">
+ <title>FPM &Functions;</title>
+
+ &reference.fpm.entities.functions;
+
+</reference>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/fpm/setup.xml
+++ b/reference/fpm/setup.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 0ba9e74ebc71fc8aa5fcd0f5f48654a4a6a83368 Maintainer: lacatoire Status: ready -->
+<!-- $Revision$ -->
+<chapter xml:id="fpm.setup">
+ &reftitle.setup;
+
+ <simpara>
+  Informacje na temat instalacji i konfiguracji FPM można znaleźć w
+  <link linkend="install.fpm">sekcji dotyczącej instalacji i konfiguracji</link>
+  podręcznika PHP.
+ </simpara>
+
+</chapter>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/fpm/status.xml
+++ b/reference/fpm/status.xml
@@ -1,0 +1,325 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: fa98755da49828e6a37049bdaf7bd16aa8adf879 Maintainer: lacatoire Status: ready -->
+<!-- $Revision$ -->
+<sect1 xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="fpm.status">
+ <title>Strona statusu</title>
+
+ <simpara>
+  Ta strona zawiera informacje o konfiguracji i zawartości strony statusu FPM. Zobacz także
+  <function>fpm_get_status</function>.
+ </simpara>
+
+ <sect2 xml:id="fpm.status.configuration">
+  <title>Konfiguracja</title>
+
+  <simpara>
+   Stronę statusu FPM można włączyć ustawiając parametr konfiguracyjny
+   <link linkend="pm.status-path">pm.status_path</link> w konfiguracji puli FPM.
+  </simpara>
+
+  <caution>
+   <simpara>
+    Ze względów bezpieczeństwa strona statusu FPM powinna być ograniczona tylko do żądań
+    wewnętrznych lub znanych adresów IP klientów, ponieważ strona ujawnia adresy URL żądań
+    i informacje o dostępnych zasobach.
+   </simpara>
+  </caution>
+
+  <simpara>
+   W zależności od konfiguracji serwera WWW może być konieczne skonfigurowanie go tak, aby
+   zezwalał na żądania bezpośrednio do tej ścieżki, omijając wszelkie skrypty PHP. Przykład
+   konfiguracji dla Apache z FPM nasłuchującym na UDS i <literal>pm.status_path</literal>
+   ustawionym na <literal>/fpm-status</literal> wyglądałby tak:
+  </simpara>
+
+  <informalexample>
+   <programlisting role="apache-conf">
+    <![CDATA[
+<LocationMatch "/fpm-status">
+ Require local
+ ProxyPass "unix:/var/run/php-fpm.sock|fcgi://localhost/"
+</LocationMatch>
+]]>
+   </programlisting>
+  </informalexample>
+
+  <simpara>
+   Po przeładowaniu lub ponownym uruchomieniu zarówno FPM, jak i serwera WWW, strona statusu
+   będzie dostępna z przeglądarki (o ile żądanie pochodzi z dozwolonego adresu IP, jeśli
+   skonfigurowano ograniczenie IP).
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="fpm.status.parameters">
+  <title>Parametry zapytania</title>
+
+  <simpara>
+   Format wyjścia strony statusu można zmienić, określając jeden z następujących parametrów
+   zapytania:
+  </simpara>
+
+  <simplelist>
+   <member><literal>html</literal></member>
+   <member><literal>json</literal></member>
+   <member><literal>openmetrics</literal></member>
+   <member><literal>xml</literal></member>
+  </simplelist>
+
+  <simpara>
+   Dodatkowe informacje można również uzyskać za pomocą parametru zapytania <literal>full</literal>.
+  </simpara>
+
+  <simpara>
+   Przykładowe adresy URL strony statusu:
+  </simpara>
+
+  <simplelist>
+   <member>
+    <literal>https://localhost/fpm-status</literal>
+    - Skrócone wyjście w domyślnym formacie tekstowym
+   </member>
+   <member>
+    <literal>https://localhost/fpm-status?full</literal>
+    - Pełne wyjście w domyślnym formacie tekstowym
+   </member>
+   <member>
+    <literal>https://localhost/fpm-status?json</literal>
+    - Skrócone wyjście w formacie JSON
+   </member>
+   <member>
+    <literal>https://localhost/fpm-status?html&amp;full</literal>
+    - Pełne wyjście w formacie HTML
+   </member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="fpm.status.contents">
+  <title>Wyświetlane informacje</title>
+
+  <simpara>
+   Wartości daty/czasu używają formatu znacznika czasu Unix w wyjściu JSON i XML, w przeciwnym
+   razie używają formatu dającego następujący przykładowy wynik daty
+   <literal>"03/Jun/2021:07:21:46 +0100"</literal>.
+  </simpara>
+
+  <table>
+   <title>Informacje podstawowe - Zawsze wyświetlane na stronie statusu</title>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>Parametr</entry>
+      <entry>Opis</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>pool</entry>
+      <entry>Nazwa puli procesów FPM.</entry>
+     </row>
+     <row>
+      <entry>proccess manager</entry>
+      <entry>Typ menedżera procesów - static, dynamic lub ondemand.</entry>
+     </row>
+     <row>
+      <entry>start time</entry>
+      <entry>Data/czas ostatniego uruchomienia puli procesów.</entry>
+     </row>
+     <row>
+      <entry>start since</entry>
+      <entry>Czas w sekundach od ostatniego uruchomienia puli procesów.</entry>
+     </row>
+     <row>
+      <entry>accepted conn</entry>
+      <entry>Całkowita liczba zaakceptowanych połączeń.</entry>
+     </row>
+     <row>
+      <entry>listen queue</entry>
+      <entry>Liczba żądań (backlog) aktualnie oczekujących na wolny proces.</entry>
+     </row>
+     <row>
+      <entry>max listen queue</entry>
+      <entry>Maksymalna liczba żądań widzianych w kolejce nasłuchiwania w dowolnym momencie.</entry>
+     </row>
+     <row>
+      <entry>listen queue len</entry>
+      <entry>Maksymalny dozwolony rozmiar kolejki nasłuchiwania.</entry>
+     </row>
+     <row>
+      <entry>idle processes</entry>
+      <entry>Liczba procesów, które są obecnie bezczynne (oczekujące na żądania).</entry>
+     </row>
+     <row>
+      <entry>active processes</entry>
+      <entry>Liczba procesów, które aktualnie przetwarzają żądania.</entry>
+     </row>
+     <row>
+      <entry>total processes</entry>
+      <entry>Bieżąca całkowita liczba procesów.</entry>
+     </row>
+     <row>
+      <entry>max active processes</entry>
+      <entry>Maksymalna liczba jednocześnie aktywnych procesów.</entry>
+     </row>
+     <row>
+      <entry>max children reached</entry>
+      <entry>
+       Czy maksymalna liczba procesów została kiedykolwiek osiągnięta? Jeśli tak, wyświetlana
+       wartość jest większa lub równa <literal>1</literal>, w przeciwnym razie wartość wynosi
+       <literal>0</literal>.
+      </entry>
+     </row>
+     <row>
+      <entry>slow requests</entry>
+      <entry>
+       Całkowita liczba żądań, które przekroczyły skonfigurowany
+       <literal>request_slowlog_timeout</literal>.
+      </entry>
+     </row>
+     <row>
+      <entry>memory peak</entry>
+      <entry>
+       Szczytowe zużycie pamięci od momentu uruchomienia FPM.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </table>
+
+  <table>
+   <title>Informacje o poszczególnych procesach - wyświetlane tylko w trybie wyjścia <literal>full</literal></title>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>Parametr</entry>
+      <entry>Opis</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>pid</entry>
+      <entry>Systemowy PID procesu.</entry>
+     </row>
+     <row>
+      <entry>state</entry>
+      <entry>Stan procesu - Idle, Running, ...</entry>
+     </row>
+     <row>
+      <entry>start time</entry>
+      <entry>Data/czas uruchomienia procesu.</entry>
+     </row>
+     <row>
+      <entry>start since</entry>
+      <entry>Liczba sekund od uruchomienia procesu.</entry>
+     </row>
+     <row>
+      <entry>requests</entry>
+      <entry>Całkowita liczba obsłużonych żądań.</entry>
+     </row>
+     <row>
+      <entry>request duration</entry>
+      <entry>Całkowity czas w mikrosekundach spędzony na obsłudze ostatniego żądania.</entry>
+     </row>
+     <row>
+      <entry>request method</entry>
+      <entry>Metoda HTTP ostatniego obsłużonego żądania.</entry>
+     </row>
+     <row>
+      <entry>request uri</entry>
+      <entry>
+       URI ostatniego obsłużonego żądania (po przetworzeniu przez serwer WWW, może to być
+       zawsze <literal>/index.php</literal> jeśli używany jest wzorzec przekierowania front
+       controller).
+      </entry>
+     </row>
+     <row>
+      <entry>content length</entry>
+      <entry>Długość treści żądania, w bajtach, ostatniego żądania.</entry>
+     </row>
+     <row>
+      <entry>user</entry>
+      <entry>Użytkownik HTTP (<literal>PHP_AUTH_USER</literal>) ostatniego żądania.</entry>
+     </row>
+     <row>
+      <entry>script</entry>
+      <entry>
+       Pełna ścieżka skryptu wykonanego przez ostatnie żądanie. Będzie to
+       <literal>'-'</literal> jeśli nie dotyczy (np. żądania strony statusu).
+      </entry>
+     </row>
+     <row>
+      <entry>last request cpu</entry>
+      <entry>
+       Procentowe zużycie CPU ostatniego żądania. Będzie wynosić 0, jeśli proces nie jest
+       bezczynny, ponieważ obliczenie jest wykonywane po zakończeniu przetwarzania żądania.
+       Wartość może przekroczyć 100%, ponieważ metryka informuje, jaki procent całkowitego
+       czasu CPU został wykorzystany w ostatnim żądaniu - uwzględnia procesy na wszystkich
+       rdzeniach, podczas gdy 100% dotyczy tylko jednego rdzenia.
+      </entry>
+     </row>
+     <row>
+      <entry>last request memory</entry>
+      <entry>
+       Maksymalna ilość pamięci zużyta przez ostatnie żądanie. Będzie wynosić 0, jeśli proces
+       nie jest bezczynny, ponieważ obliczenie jest wykonywane po zakończeniu przetwarzania
+       żądania.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </table>
+
+  <note>
+   <simpara>
+    Wszystkie wartości są specyficzne dla puli i są resetowane po ponownym uruchomieniu FPM.
+   </simpara>
+  </note>
+
+  <note>
+   <simpara>
+    Wyjście w formacie OpenMetrics używa różnych typów parametrów, aby lepiej pasować do
+    formatu OpenMetrics. Parametry i opisy ich wartości są zawarte w wyjściu formatu
+    OpenMetrics.
+   </simpara>
+  </note>
+ </sect2>
+
+ <sect2 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.1.0</entry>
+      <entry>Dodano format openmetrics.</entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </sect2>
+</sect1>
+<!-- Keep this comment at the end of the file
+ Local variables:
+ mode: sgml
+ sgml-omittag:t
+ sgml-shorttag:t
+ sgml-minimize-attributes:nil
+ sgml-always-quote-attributes:t
+ sgml-indent-step:1
+ sgml-indent-data:t
+ indent-tabs-mode:nil
+ sgml-parent-document:nil
+ sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+ sgml-exposed-tags:nil
+ sgml-local-catalogs:nil
+ sgml-local-ecat-files:nil
+ End:
+ vim600: syn=xml fen fdm=syntax fdl=2 si
+ vim: et tw=78 syn=sgml
+ vi: ts=1 sw=1
+ -->

--- a/reference/fpm/versions.xml
+++ b/reference/fpm/versions.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: fab4ea95f4fe1471be947602d0e9be32fb802265 Maintainer: lacatoire Status: ready -->
+<!-- $Revision$ -->
+<!--
+  Do NOT translate this file
+-->
+
+<versions>
+ <function name="fastcgi_finish_request" from="PHP 5 &gt;= 5.3.3, PHP 7, PHP 8"/>
+ <function name="fpm_get_status" from="PHP 7 &gt;= 7.3, PHP 8"/>
+</versions>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Add complete Polish translation for the FPM (FastCGI Process Manager) reference documentation, including status page, observability, and function pages.