### PR TITLE
Add Polish translation for missing predefined classes

### DIFF
--- a/language/predefined/attributes/nodiscard.xml
+++ b/language/predefined/attributes/nodiscard.xml
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 02bee41067ab2822cbffcb4b3b2387f79488dffd Maintainer: lacatoire Status: ready -->
+<reference xml:id="class.nodiscard" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>Atrybut NoDiscard</title>
+ <titleabbrev>NoDiscard</titleabbrev>
+
+ <partintro>
+
+  <section xml:id="nodiscard.intro">
+   &reftitle.intro;
+   <simpara>
+    Ten atrybut może być użyty do wskazania, że wartość zwracana przez funkcję
+    lub metodę nie powinna być odrzucana. Jeśli wartość zwracana nie zostanie
+    w żaden sposób wykorzystana, zostanie wyemitowane ostrzeżenie.
+   </simpara>
+   <simpara>
+    Jest to przydatne w przypadku funkcji, w których niesprawdzenie wartości
+    zwracanej prawdopodobnie jest błędem.
+   </simpara>
+   <simpara>
+    Aby celowo odrzucić wartość zwracaną takiej funkcji, należy użyć rzutowania
+    (void) w celu wyciszenia ostrzeżenia.
+   </simpara>
+   <note>
+    <simpara>
+     Ponieważ atrybuty są zaprojektowane tak, aby były wstecznie kompatybilne,
+     <code>#[\NoDiscard]</code> może być dodany do funkcji i metod nawet gdy
+     obsługiwane jest PHP 8.4 lub niższe — po prostu nic nie zrobi.
+     W PHP 8.5 i nowszych zostanie wyemitowane ostrzeżenie, jeśli wynik nie
+     zostanie wykorzystany. Aby wyciszyć ostrzeżenie bez użycia
+     <code>(void)</code>, które nie jest obsługiwane przed PHP 8.5,
+     rozważ użycie zmiennej takiej jak <code>$_</code>.
+    </simpara>
+   </note>
+  </section>
+
+  <section xml:id="nodiscard.synopsis">
+   &reftitle.classsynopsis;
+
+   <classsynopsis class="class">
+    <ooclass>
+     <modifier>final</modifier>
+     <classname>NoDiscard</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>string</type><type>null</type></type>
+     <varname linkend="nodiscard.props.message">message</varname>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.nodiscard')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='NoDiscard'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+
+  </section>
+
+  <section xml:id="nodiscard.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="nodiscard.props.message">
+     <term><varname>message</varname></term>
+     <listitem>
+      <simpara>
+       Opcjonalna wiadomość wyjaśniająca, dlaczego wartość zwracana nie powinna
+       być odrzucana.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+
+  <section>
+   &reftitle.examples;
+   <example>
+    <title>Podstawowe użycie</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+/**
+ * Przetwarza wszystkie podane elementy i zwraca tablicę z wynikami operacji
+ * dla każdego elementu. `null` oznacza sukces, a Exception oznacza błąd.
+ * Klucze tablicy wynikowej odpowiadają kluczom tablicy $items.
+ *
+ * @param array<string> $items
+ * @return array<null|Exception>
+ */
+#[\NoDiscard("as processing might fail for individual items")]
+function bulk_process(array $items): array {
+	$results = [];
+
+	foreach ($items as $key => $item) {
+		if (\random_int(0, 9999) < 9999) {
+			// Pretend to do something useful with $item,
+			// which will succeed in 99.99% of cases.
+			echo "Processing {$item}", PHP_EOL;
+			$error = null;
+		} else {
+			$error = new \Exception("Failed to process {$item}.");
+		}
+
+		$results[$key] = $error;
+	}
+
+	return $results;
+}
+
+bulk_process($items);
+
+?>
+]]>
+    </programlisting>
+    &example.outputs.85.similar;
+    <screen>
+<![CDATA[
+Warning: The return value of function bulk_process() should either be used or intentionally ignored by casting it as (void), as processing might fail for individual items
+]]>
+    </screen>
+   </example>
+   <example>
+    <title>Celowe odrzucenie wartości zwracanej</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+#[\NoDiscard]
+function some_command(): int {
+    return 1;
+}
+
+// Suppress the warning using (void) - PHP 8.5+
+(void) some_command();
+
+// For compatibility with PHP versions before 8.5, use a temporary variable
+$_ = some_command();
+
+?>
+]]>
+    </programlisting>
+   </example>
+  </section>
+
+  <section xml:id="nodiscard.seealso">
+   &reftitle.seealso;
+   <simplelist>
+    <member><link linkend="language.attributes">Przegląd atrybutów</link></member>
+   </simplelist>
+  </section>
+
+ </partintro>
+
+ &language.predefined.attributes.nodiscard.construct;
+
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/language/predefined/attributes/nodiscard/construct.xml
+++ b/language/predefined/attributes/nodiscard/construct.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 02bee41067ab2822cbffcb4b3b2387f79488dffd Maintainer: lacatoire Status: ready -->
+<!-- $Revision$ -->
+<refentry xml:id="nodiscard.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>NoDiscard::__construct</refname>
+  <refpurpose>Tworzy nową instancję atrybutu NoDiscard</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis role="NoDiscard">
+   <modifier>public</modifier> <methodname>NoDiscard::__construct</methodname>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>message</parameter><initializer>&null;</initializer></methodparam>
+  </constructorsynopsis>
+  <simpara>
+   Tworzy nową instancję <classname>NoDiscard</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>message</parameter></term>
+    <listitem>
+     <simpara>
+      Wartość właściwości <property linkend="nodiscard.props.message">message</property>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/language/predefined/closure/getcurrent.xml
+++ b/language/predefined/closure/getcurrent.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 31e56c25f90ebedf9aa4aa4877fbc859e1e0529c Maintainer: lacatoire Status: ready -->
+<!-- $Revision$ -->
+<refentry xml:id="closure.getcurrent" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Closure::getCurrent</refname>
+  <refpurpose>Zwraca aktualnie wykonywaną domknięcie</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Closure">
+   <modifier>public</modifier> <modifier>static</modifier> <type>Closure</type><methodname>Closure::getCurrent</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Zwraca aktualnie wykonywaną domknięcie. Ta metoda jest przydatna głównie
+   do implementacji rekurencyjnych domknięć bez konieczności przechwytywania
+   referencji do zmiennej domknięcia za pomocą słowa kluczowego
+   <literal>use</literal>.
+  </para>
+  <para>
+   Ta metoda musi być wywołana z wnętrza domknięcia; wywołanie jej poza
+   kontekstem domknięcia spowoduje błąd
+   <literal>Error: Current function is not a closure.</literal>
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Zwraca aktualnie wykonywaną instancję <classname>Closure</classname>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Rzuca <classname>Error</classname> jeśli zostanie wywołana poza kontekstem
+   domknięcia.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="closure.getcurrent.example.basic">
+   <title>Przykład użycia <methodname>Closure::getCurrent</methodname></title>
+   <para>
+    Użycie <methodname>Closure::getCurrent</methodname> do implementacji
+    rekurencyjnej funkcji Fibonacci:
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$fibonacci = function (int $n) {
+    if ($n === 0 || $n === 1) {
+        return $n;
+    }
+
+    $fn = Closure::getCurrent();
+    return $fn($n - 1) + $fn($n - 2);
+};
+
+echo $fibonacci(10); // Outputs: 55
+?>
+]]>
+   </programlisting>
+  </example>
+  <example xml:id="closure.getcurrent.example.comparison">
+   <title>Porównanie z tradycyjnym podejściem</title>
+   <para>
+    Przed PHP 8.5 implementacja rekurencyjnych domknięć wymagała przechwycenia
+    referencji do zmiennej domknięcia za pomocą słowa kluczowego
+    <literal>use</literal>:
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+// Traditional approach (still works in PHP 8.5)
+$fibonacci = function (int $n) use (&$fibonacci) {
+    if ($n === 0) return 0;
+    if ($n === 1) return 1;
+    return $fibonacci($n - 1) + $fibonacci($n - 2);
+};
+
+echo $fibonacci(10); // Outputs: 55
+?>
+]]>
+   </programlisting>
+   <para>
+    Podejście z <methodname>Closure::getCurrent</methodname> eliminuje
+    konieczność deklarowania zmiennej z referencją w klauzuli
+    <literal>use</literal>, co sprawia, że kod jest czystszy i mniej
+    podatny na błędy.
+   </para>
+  </example>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/language/predefined/weakreference/construct.xml
+++ b/language/predefined/weakreference/construct.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: d27fdfe8f990c14955354176a615e6e8daeb0525 Maintainer: lacatoire Status: ready -->
+<!-- $Revision$ -->
+<refentry xml:id="weakreference.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>WeakReference::__construct</refname>
+  <refpurpose>Konstruktor uniemożliwiający tworzenie instancji</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis role="WeakReference">
+   <modifier>public</modifier> <methodname>WeakReference::__construct</methodname>
+   <void/>
+  </constructorsynopsis>
+  <para>
+   Ta metoda istnieje wyłącznie w celu uniemożliwienia tworzenia instancji klasy
+   <classname>WeakReference</classname>. Słabe referencje należy tworzyć za pomocą
+   metody fabrykującej <methodname>WeakReference::create</methodname>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <!-- Return values commented out, as constructors generally don't return a
+      value. Uncomment this if you do need a return values section (for
+      example, because there's also a procedural version of the method).
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+
+  </para>
+ </refsect1>
+ -->
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>WeakReference::create</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/language/predefined/weakreference/create.xml
+++ b/language/predefined/weakreference/create.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 430a41f572273e5c702ffea3da354ff28a21496b Maintainer: lacatoire Status: ready -->
+<!-- $Revision$ -->
+<refentry xml:id="weakreference.create" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>WeakReference::create</refname>
+  <refpurpose>Tworzy nową słabą referencję</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="WeakReference">
+   <modifier>public</modifier> <modifier>static</modifier> <type>WeakReference</type><methodname>WeakReference::create</methodname>
+   <methodparam><type>object</type><parameter>object</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Tworzy nową instancję <classname>WeakReference</classname>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>object</parameter></term>
+    <listitem>
+     <para>
+      Obiekt, do którego ma być utworzona słaba referencja.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Zwraca nową instancję <classname>WeakReference</classname> lub istniejącą
+   instancję, jeśli słaba referencja do tego samego obiektu już istnieje.
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/language/predefined/weakreference/get.xml
+++ b/language/predefined/weakreference/get.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: d27fdfe8f990c14955354176a615e6e8daeb0525 Maintainer: lacatoire Status: ready -->
+<!-- $Revision$ -->
+<refentry xml:id="weakreference.get" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>WeakReference::get</refname>
+  <refpurpose>Pobiera obiekt ze słabą referencją</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="WeakReference">
+   <modifier>public</modifier> <type class="union"><type>object</type><type>null</type></type><methodname>WeakReference::get</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Pobiera obiekt ze słabą referencją.
+   Jeśli obiekt został już zniszczony, zwracane jest &null;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Zwraca obiekt wskazywany przez referencję (&object;) lub &null;, jeśli
+   obiekt został zniszczony.
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Add Polish translations for missing predefined class documentation: NoDiscard attribute, Closure::getCurrent, and WeakReference methods.